### PR TITLE
Migrate JiraAgilePS to shared standards v0.1.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,124 @@
+name: CI
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+on:
+  pull_request:
+    branches: [master]
+    paths-ignore: &paths-ignore
+      - "CHANGELOG.md"
+      - "LICENSE"
+      - ".github/*.md"
+      - ".github/ISSUE_TEMPLATE/**"
+      - ".github/PULL_REQUEST_TEMPLATE/**"
+      - ".vscode/**"
+      - ".editorconfig"
+      - ".spelling"
+  push:
+    branches: [master]
+    paths-ignore: *paths-ignore
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Build Module
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: AtlassianPS/AtlassianPS.Standards/.github/actions/setup-powershell@v0.1.2
+
+      - name: Build
+        run: Invoke-Build -Task ShowInfo, Clean, Build
+        shell: pwsh
+
+      - name: Upload release artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: Release
+          path: ./Release/
+
+  test_windows_ps5:
+    name: Test (Windows PS5)
+    needs: build
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: AtlassianPS/AtlassianPS.Standards/.github/actions/setup-powershell@v0.1.2
+        with:
+          ps-version: "5"
+          skip-setup: "true"
+
+      - name: Setup dependencies
+        run: |
+          ./Tools/setup.ps1
+          Invoke-Build -Task ShowDebugInfo
+        shell: powershell
+
+      - name: Download release artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: Release
+          path: ./Release/
+
+      - name: Test
+        run: Invoke-Build -Task Test
+        shell: powershell
+
+      - name: Upload unit test results
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: Windows-PS5-Unit-Tests
+          path: Test*.xml
+
+  test_pwsh:
+    name: Test (${{ matrix.name }})
+    needs: build
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { os: windows-latest, name: "Windows PS7" }
+          - { os: ubuntu-latest, name: "Ubuntu" }
+          - { os: macos-latest, name: "macOS" }
+    steps:
+      - uses: actions/checkout@v6
+      - uses: AtlassianPS/AtlassianPS.Standards/.github/actions/setup-powershell@v0.1.2
+
+      - name: Download release artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: Release
+          path: ./Release/
+
+      - name: Test
+        run: Invoke-Build -Task Test
+        shell: pwsh
+
+      - name: Upload unit test results
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: ${{ matrix.name }}-Unit-Tests
+          path: Test*.xml
+
+  ci-required:
+    name: CI Result
+    if: always()
+    needs: [build, test_windows_ps5, test_pwsh]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Aggregate job results
+        shell: bash
+        run: |
+          results='${{ toJSON(needs) }}'
+          echo "Job results:"
+          echo "$results"
+          if echo "$results" | grep -E '"result":[[:space:]]*"(failure|cancelled)"' > /dev/null; then
+            echo "::error::One or more required jobs failed or were cancelled."
+            exit 1
+          fi
+          echo "All required jobs passed or were skipped."

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -1,0 +1,16 @@
+name: "Copilot Setup Steps"
+
+on:
+  workflow_dispatch:
+
+jobs:
+  copilot-setup-steps:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: AtlassianPS/AtlassianPS.Standards/.github/actions/setup-powershell@v0.1.2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,75 @@
+name: Create Release and Publish
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: "Tag to release (for manual reruns)"
+        required: true
+        type: string
+
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.release_tag || github.ref_name }}
+
+      - name: Resolve release ref
+        id: release_ref
+        shell: bash
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            release_tag="${{ inputs.release_tag }}"
+          else
+            release_tag="${{ github.ref_name }}"
+          fi
+
+          release_sha="$(git rev-list -n 1 "$release_tag")"
+          echo "release_tag=$release_tag" >> "$GITHUB_OUTPUT"
+          echo "release_sha=$release_sha" >> "$GITHUB_OUTPUT"
+
+      - name: Download artifact from tagged commit CI run
+        uses: dawidd6/action-download-artifact@v21
+        with:
+          workflow: ci.yml
+          workflow_conclusion: success
+          commit: ${{ steps.release_ref.outputs.release_sha }}
+          name: Release
+          path: ./Release/
+          if_no_artifact_found: fail
+
+      - uses: AtlassianPS/AtlassianPS.Standards/.github/actions/setup-powershell@v0.1.2
+
+      - name: Publish to PowerShell Gallery
+        shell: pwsh
+        run: |
+          Import-Module AtlassianPS.Standards -RequiredVersion 0.1.2 -ErrorAction Stop
+          Publish-AtlassianPSModuleRelease -BuildOutputPath ./Release -ModuleName JiraAgilePS -ApiKey ${{ secrets.PSGALLERY_API_KEY }}
+
+      - name: Package release zip
+        shell: pwsh
+        run: |
+          Import-Module AtlassianPS.Standards -RequiredVersion 0.1.2 -ErrorAction Stop
+          $null = New-AtlassianPSModulePackage -BuildOutputPath ./Release -ModuleName JiraAgilePS
+
+      - name: Create Release and Upload Asset
+        uses: softprops/action-gh-release@v3
+        with:
+          tag_name: ${{ steps.release_ref.outputs.release_tag }}
+          name: ${{ steps.release_ref.outputs.release_tag }}
+          files: ./Release/JiraAgilePS.zip
+          fail_on_unmatched_files: true
+          draft: false
+          prerelease: ${{ contains(steps.release_ref.outputs.release_tag, 'alpha') || contains(steps.release_ref.outputs.release_tag, 'beta') || contains(steps.release_ref.outputs.release_tag, 'rc') }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/JiraAgilePS.build.ps1
+++ b/JiraAgilePS.build.ps1
@@ -113,6 +113,9 @@ task ShowInfo Init, GetNextVersion, {
     Write-Build Gray ('OS Version:                 {0}' -f $OSVersion)
     Write-Build Gray
 }
+
+# Synopsis: Compatibility alias expected by shared setup action
+task ShowDebugInfo ShowInfo
 #endregion DebugInformation
 
 #region BuildRelease
@@ -138,9 +141,20 @@ task CopyModuleFiles {
 
 # Synopsis: Prepare tests for ./Release
 task PrepareTests Init, {
-    $null = New-Item -Path "$env:BHBuildOutput/Tests" -ItemType Directory -ErrorAction SilentlyContinue
-    Copy-Item -Path "$env:BHProjectPath/Tests" -Destination $env:BHBuildOutput -Recurse -Force
-    Copy-Item -Path "$env:BHProjectPath/PSScriptAnalyzerSettings.psd1" -Destination $env:BHBuildOutput -Force
+    $null = New-Item -Path "$env:BHBuildOutput/Tests" -ItemType Directory -Force -ErrorAction SilentlyContinue
+
+    $testsPath = "$env:BHProjectPath/Tests"
+    if (Test-Path $testsPath) {
+        Copy-Item -Path $testsPath -Destination $env:BHBuildOutput -Recurse -Force
+    }
+    else {
+        Write-Warning "No Tests directory found at '$testsPath'. Continuing without bundled tests."
+    }
+
+    $analyzerSettingsPath = "$env:BHProjectPath/PSScriptAnalyzerSettings.psd1"
+    if (Test-Path $analyzerSettingsPath) {
+        Copy-Item -Path $analyzerSettingsPath -Destination $env:BHBuildOutput -Force
+    }
 }
 
 # Synopsis: Compile all functions into the .psm1 file
@@ -181,7 +195,9 @@ task CompileModule Init, {
 
 # Synopsis: Use PlatyPS to generate External-Help
 task GenerateExternalHelp Init, {
-    Import-Module platyPS -Force
+    if (-not (Get-Module -Name platyPS)) {
+        Import-Module platyPS -Force
+    }
     foreach ($locale in (Get-ChildItem "$env:BHProjectPath/docs" -Attribute Directory)) {
         New-ExternalHelp -Path "$($locale.FullName)" -OutputPath "$env:BHModulePath/$($locale.Basename)" -Force
         New-ExternalHelp -Path "$($locale.FullName)/commands" -OutputPath "$env:BHModulePath/$($locale.Basename)" -Force
@@ -218,6 +234,13 @@ task Test Init, {
     Assert-True { Test-Path $env:BHBuildOutput -PathType Container } "Release path must exist"
 
     Remove-Module $env:BHProjectName -ErrorAction SilentlyContinue
+
+    $testScriptPath = "$env:BHBuildOutput/Tests"
+    $testScripts = @(Get-ChildItem -Path $testScriptPath -Filter '*.ps1' -File -Recurse -ErrorAction SilentlyContinue)
+    if (-not $testScripts) {
+        Write-Warning "No test files found at '$testScriptPath'. Skipping Test task."
+        return
+    }
 
     <# $params = @{
         Path    = "$env:BHBuildOutput/$env:BHProjectName"

--- a/PSScriptAnalyzerSettings.psd1
+++ b/PSScriptAnalyzerSettings.psd1
@@ -1,5 +1,118 @@
+﻿# From https://github.com/PowerShell/PSScriptAnalyzer/blob/master/Engine/Settings/CodeFormattingStroustrup.psd1
+# Inspired by https://eslint.org/docs/rules/brace-style#stroustrup
 @{
-    Severity     = @('Error', 'Warning')
-    # IncludeRules = @()
-    # ExcludeRules = @()
+    IncludeRules = @(
+        # CmdletDesign
+        'PSUseApprovedVerbs',
+        'PSReservedCmdletChar',
+        'PSReservedParams',
+        'PSShouldProcess',
+        'PSUseShouldProcessForStateChangingFunctions',
+        'PSUseSingularNouns',
+        'PSMissingModuleManifestField',
+        'PSAvoidDefaultValueSwitchParameter',
+
+        # CodeFormattingStroustrup
+        'PSPlaceOpenBrace',
+        'PSPlaceCloseBrace',
+        'PSUseConsistentWhitespace',
+        'PSUseConsistentIndentation',
+        'PSAlignAssignmentStatement',
+        'PSUseCorrectCasing',
+
+        # PSGallery
+        'PSUseApprovedVerbs',
+        'PSReservedCmdletChar',
+        'PSReservedParams',
+        'PSShouldProcess',
+        'PSUseShouldProcessForStateChangingFunctions',
+        'PSUseSingularNouns',
+        'PSMissingModuleManifestField',
+        'PSAvoidDefaultValueSwitchParameter',
+        'PSAvoidUsingCmdletAliases',
+        'PSAvoidUsingWMICmdlet',
+        'PSAvoidUsingEmptyCatchBlock',
+        'PSUseCmdletCorrectly',
+        'PSUseShouldProcessForStateChangingFunctions',
+        'PSAvoidUsingPositionalParameters',
+        'PSAvoidGlobalVars',
+        'PSUseDeclaredVarsMoreThanAssignments',
+        'PSAvoidUsingInvokeExpression',
+        'PSAvoidUsingPlainTextForPassword',
+        'PSAvoidUsingComputerNameHardcoded',
+        'PSUsePSCredentialType',
+        'PSDSC*',
+
+        # ScriptFunctions
+        'PSAvoidUsingCmdletAliases',
+        'PSAvoidUsingWMICmdlet',
+        'PSAvoidUsingEmptyCatchBlock',
+        'PSUseCmdletCorrectly',
+        'PSUseShouldProcessForStateChangingFunctions',
+        'PSAvoidUsingPositionalParameters',
+        'PSAvoidGlobalVars',
+        'PSUseDeclaredVarsMoreThanAssignments',
+        'PSAvoidUsingInvokeExpression',
+
+        # ScriptSecurity
+        'PSAvoidUsingPlainTextForPassword',
+        'PSAvoidUsingComputerNameHardcoded',
+        'PSAvoidUsingConvertToSecureStringWithPlainText',
+        'PSUsePSCredentialType',
+        'PSAvoidUsingUserNameAndPasswordParams',
+
+        # ScriptingStyle
+        'PSProvideCommentHelp',
+        'PSAvoidUsingWriteHost'
+    )
+
+    Rules        = @{
+        PSPlaceOpenBrace           = @{
+            Enable             = $true
+            OnSameLine         = $true
+            NewLineAfter       = $true
+            IgnoreOneLineBlock = $true
+        }
+
+        PSPlaceCloseBrace          = @{
+            Enable             = $true
+            NewLineAfter       = $true
+            IgnoreOneLineBlock = $true
+            NoEmptyLineBefore  = $false
+        }
+
+        PSUseConsistentIndentation = @{
+            Enable              = $true
+            Kind                = 'space'
+            PipelineIndentation = 'IncreaseIndentationForFirstPipeline'
+            IndentationSize     = 4
+        }
+
+        PSUseConsistentWhitespace  = @{
+            Enable                                  = $true
+            CheckInnerBrace                         = $true
+            CheckOpenBrace                          = $true
+            CheckOpenParen                          = $true
+            CheckOperator                           = $true
+            CheckPipe                               = $true
+            CheckPipeForRedundantWhitespace         = $false
+            CheckSeparator                          = $true
+            CheckParameter                          = $false
+            IgnoreAssignmentOperatorInsideHashTable = $true
+        }
+
+        PSAlignAssignmentStatement = @{
+            Enable         = $true
+            CheckHashtable = $true
+        }
+
+        PSUseCorrectCasing         = @{
+            Enable = $true
+        }
+
+        PSAvoidUsingCmdletAliases  = @{
+            Enable    = $true
+            Whitelist = @('Task')
+        }
+    }
 }

--- a/Tools/build.requirements.psd1
+++ b/Tools/build.requirements.psd1
@@ -1,8 +1,8 @@
 @(
+    @{ ModuleName = "AtlassianPS.Standards"; RequiredVersion = "0.1.2" }
     @{ ModuleName = "JiraPS"; RequiredVersion = "2.12.2" }
     @{ ModuleName = "InvokeBuild"; RequiredVersion = "5.5.5" }
     @{ ModuleName = "BuildHelpers"; RequiredVersion = "2.0.11" }
     @{ ModuleName = "Pester"; RequiredVersion = "4.9.0" }
     @{ ModuleName = "platyPS"; RequiredVersion = "0.14.0" }
-    @{ ModuleName = "PSScriptAnalyzer"; RequiredVersion = "1.18.3" }
 )

--- a/Tools/setup.ps1
+++ b/Tools/setup.ps1
@@ -4,6 +4,26 @@
 [System.Diagnostics.CodeAnalysis.SuppressMessage('PSAvoidUsingWriteHost', '')]
 param()
 
+$psScriptAnalyzerSettingsPath = Join-Path (Join-Path $PSScriptRoot '..') 'PSScriptAnalyzerSettings.psd1'
+
+function Sync-PSScriptAnalyzerSetting {
+    [CmdletBinding()]
+    param()
+
+    Write-Host "Syncing PSScriptAnalyzer settings from AtlassianPS.Standards"
+
+    try {
+        Import-Module AtlassianPS.Standards -RequiredVersion '0.1.2' -Force -ErrorAction Stop
+        $resolvedSettingsPath = Sync-AtlassianPSScriptAnalyzerSettings `
+            -DestinationPath $psScriptAnalyzerSettingsPath `
+            -ErrorAction Stop
+        Write-Host "Shared PSScriptAnalyzer settings synchronized to '$resolvedSettingsPath'."
+    }
+    catch {
+        throw "Unable to sync PSScriptAnalyzer settings from AtlassianPS.Standards. $($_.Exception.Message)"
+    }
+}
+
 # PowerShell 5.1 and bellow need the PSGallery to be intialized
 if (-not ($gallery = Get-PSRepository -Name PSGallery -ErrorAction SilentlyContinue)) {
     Write-Host "Installing PackageProvider NuGet"
@@ -21,3 +41,5 @@ Install-Module InvokeBuild -Scope CurrentUser -Force
 
 Write-Host "Installing Dependencies"
 Invoke-Build -Task InstallDependencies
+
+Sync-PSScriptAnalyzerSetting


### PR DESCRIPTION
## Summary
- add GitHub Actions workflows (CI, release, copilot setup) wired to AtlassianPS.Standards setup action at v0.1.2
- sync PSScriptAnalyzerSettings.psd1 from AtlassianPS.Standards in Tools/setup.ps1
- pin AtlassianPS.Standards 0.1.2 in build requirements
- add ShowDebugInfo compatibility task and harden build and test tasks for repos without a Tests directory

## Validation
- ./Tools/setup.ps1
- Invoke-Build -Task ShowDebugInfo, Build, Test
