### PR TITLE
Restore explicit PSScriptAnalyzer build dependency

### DIFF
--- a/Tools/build.requirements.psd1
+++ b/Tools/build.requirements.psd1
@@ -4,5 +4,6 @@
     @{ ModuleName = "InvokeBuild"; RequiredVersion = "5.5.5" }
     @{ ModuleName = "BuildHelpers"; RequiredVersion = "2.0.11" }
     @{ ModuleName = "Pester"; RequiredVersion = "4.9.0" }
+    @{ ModuleName = "PSScriptAnalyzer"; RequiredVersion = "1.25.0" }
     @{ ModuleName = "platyPS"; RequiredVersion = "0.14.0" }
 )


### PR DESCRIPTION
## Summary
- restore explicit `PSScriptAnalyzer` entry in `Tools/build.requirements.psd1`
- pin it to `1.25.0` to match the version required by `AtlassianPS.Standards`

## Why
Local lint prerequisites should stay explicit for developers, but the version must align with shared standards to avoid mixed-version type-data conflicts.

## Validation
- `./Tools/setup.ps1`
- `Invoke-Build -Task ShowDebugInfo, Build, Test`
