### PR TITLE
Add JiraAgilePS AI instruction baseline and legacy-safe guidance

### DIFF
--- a/.cursor/rules/jiraagileps.mdc
+++ b/.cursor/rules/jiraagileps.mdc
@@ -14,9 +14,10 @@ Canonical sources:
 
 1. Scope each change to one behavior; update tests/docs/changelog when impacted and available.
 2. Route Jira API interactions through `Invoke-JiraMethod` and preserve Cloud/Data Center behavior.
-3. Validate from repo root with `./Tools/setup.ps1` then `Invoke-Build -Task Build, Test`.
-4. This repo may have no `Tests/`; validation can warn/skip tests—report exact outcomes.
-5. Public function sources are unprefixed (for example `Get-Board`) and exported with `JiraAgile` prefix.
+3. During iteration, run targeted tests when present (for example `Invoke-Pester -Path 'Tests/Functions/Public/Get-Board.Unit.Tests.ps1'`).
+4. Before finalizing, validate from repo root with `./Tools/setup.ps1` then `Invoke-Build -Task Build, Test`.
+5. This repo may have no `Tests/`; validation can warn/skip tests—report exact outcomes.
+6. Public function sources are unprefixed (for example `Get-Board`) and exported with `JiraAgile` prefix.
 
 ## File Locations
 

--- a/.cursor/rules/jiraagileps.mdc
+++ b/.cursor/rules/jiraagileps.mdc
@@ -1,0 +1,26 @@
+---
+description: JiraAgilePS project-wide development rules (Cursor entry point)
+alwaysApply: true
+---
+
+# Cursor Entry Point
+
+Canonical sources:
+
+- Project rules: [AGENTS.md](../../AGENTS.md)
+- PowerShell rules: [.github/ai-context/powershell-rules.md](../../.github/ai-context/powershell-rules.md)
+
+## Quick Reference
+
+1. Scope each change to one behavior; update tests/docs/changelog when impacted and available.
+2. Route Jira API interactions through `Invoke-JiraMethod` and preserve Cloud/Data Center behavior.
+3. Validate from repo root with `./Tools/setup.ps1` then `Invoke-Build -Task Build, Test`.
+4. This repo may have no `Tests/`; validation can warn/skip tests—report exact outcomes.
+5. Public function sources are unprefixed (for example `Get-Board`) and exported with `JiraAgile` prefix.
+
+## File Locations
+
+- Public functions: `JiraAgilePS/Public/`
+- Private functions: `JiraAgilePS/Private/`
+- Tests (optional legacy coverage): `Tests/` (copied to `Release/Tests/` when present)
+- Docs/help sources: `docs/en-US/commands/` (add files when command help changes)

--- a/.github/ai-context/powershell-rules.md
+++ b/.github/ai-context/powershell-rules.md
@@ -1,0 +1,51 @@
+# JiraAgilePS PowerShell Rules
+
+This file captures practical coding/build/test rules shared across AI entry points.
+
+## Build and Test Commands
+
+```powershell
+./Tools/setup.ps1
+Invoke-Build -Task Build, Test
+```
+
+Canonical non-interactive invocation:
+
+```powershell
+pwsh -NoLogo -NonInteractive -NoProfile -Command "Set-Location '<repo-root>'; ./Tools/setup.ps1; Invoke-Build -Task Build, Test"
+```
+
+Validation expectations for this repository's current legacy state:
+
+- `Invoke-Build -Task Test` runs from `Release/Tests/` and may warn/skip when no `Tests/*.ps1` files exist.
+- Do not claim validation passed if `Build` or `Test` fails; include failing task and error.
+- Use focused `Invoke-Pester` runs when test files exist.
+- When changing behavior without existing coverage, add tests where practical.
+
+## Source Layout
+
+- Public cmdlets: `JiraAgilePS/Public/*.ps1`
+- Private helpers/converters: `JiraAgilePS/Private/*.ps1`
+- Public source names are unprefixed (`Get-Board`, `Get-Sprint`) and module import applies `JiraAgile` command prefix.
+- Build script: `JiraAgilePS.build.ps1`
+- Docs/help sources: `docs/en-US/commands/*.md`
+- Tests: `Tests/**/*.ps1` (optional legacy coverage; copied into `Release/Tests/` by build when present)
+
+## API and REST Conventions
+
+- Route Jira API calls through `Invoke-JiraMethod`.
+- Avoid introducing direct web calls in cmdlet implementations.
+- Keep paging and credential behavior aligned with existing cmdlets.
+
+## Coding Conventions
+
+- Follow existing cmdlet and converter patterns.
+- Keep changes focused and avoid wide refactors in bug-fix branches.
+- Add comments only for non-obvious constraints or decisions.
+- Use `#ToDo:<Category>` markers for explicit debt tracking.
+
+## Documentation Conventions
+
+- User-facing command documentation belongs in `docs/en-US/commands/*.md`.
+- This repo currently has sparse command docs; add/extend command pages when behavior changes.
+- Include changelog updates for user-visible behavior changes.

--- a/.github/ai-context/powershell-rules.md
+++ b/.github/ai-context/powershell-rules.md
@@ -19,7 +19,7 @@ Validation expectations for this repository's current legacy state:
 
 - `Invoke-Build -Task Test` runs from `Release/Tests/` and may warn/skip when no `Tests/*.ps1` files exist.
 - Do not claim validation passed if `Build` or `Test` fails; include failing task and error.
-- Use focused `Invoke-Pester` runs when test files exist.
+- During iteration, use focused `Invoke-Pester` runs when test files exist (for example `Invoke-Pester -Path 'Tests/Functions/Public/Get-Board.Unit.Tests.ps1'`).
 - When changing behavior without existing coverage, add tests where practical.
 
 ## Source Layout
@@ -36,6 +36,13 @@ Validation expectations for this repository's current legacy state:
 - Route Jira API calls through `Invoke-JiraMethod`.
 - Avoid introducing direct web calls in cmdlet implementations.
 - Keep paging and credential behavior aligned with existing cmdlets.
+- Jira Agile endpoints in this module are based on `/rest/agile/1.0`; keep Cloud/Data Center compatibility behavior explicit.
+
+## Supported API Reference Tracks
+
+- Cloud (supported research target): Jira Software Cloud REST API: https://developer.atlassian.com/cloud/jira/software/rest/
+- Data Center/Server (supported research target): Jira Software Server/Data Center REST API: https://docs.atlassian.com/jira-software/REST/latest/
+- Before adopting or changing endpoint/field behavior, verify against both references unless the task is explicitly Cloud-only or Data Center-only.
 
 ## Coding Conventions
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -4,14 +4,16 @@ GitHub Copilot should treat these files as canonical:
 
 - Project rules: [../AGENTS.md](../AGENTS.md)
 - PowerShell rules: [ai-context/powershell-rules.md](ai-context/powershell-rules.md)
+- File-pattern rules: [instructions/](instructions/)
 
 ## Quick Reference
 
 1. Scope each change to one behavior; update tests/docs/changelog when impacted and available.
 2. Route Jira API interactions through `Invoke-JiraMethod` and preserve Cloud/Data Center behavior.
-3. Validate from repo root with `./Tools/setup.ps1` then `Invoke-Build -Task Build, Test`.
-4. This repo may have no `Tests/`; validation can warn/skip tests—report exact outcomes.
-5. Public function sources are unprefixed (for example `Get-Board`) and exported with `JiraAgile` prefix.
+3. During iteration, run targeted tests when present (for example `Invoke-Pester -Path 'Tests/Functions/Public/Get-Board.Unit.Tests.ps1'`).
+4. Before finalizing, validate from repo root with `./Tools/setup.ps1` then `Invoke-Build -Task Build, Test`.
+5. This repo may have no `Tests/`; validation can warn/skip tests—report exact outcomes.
+6. Public function sources are unprefixed (for example `Get-Board`) and exported with `JiraAgile` prefix.
 
 ## File Locations
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,21 @@
+# GitHub Copilot Entry Point
+
+GitHub Copilot should treat these files as canonical:
+
+- Project rules: [../AGENTS.md](../AGENTS.md)
+- PowerShell rules: [ai-context/powershell-rules.md](ai-context/powershell-rules.md)
+
+## Quick Reference
+
+1. Scope each change to one behavior; update tests/docs/changelog when impacted and available.
+2. Route Jira API interactions through `Invoke-JiraMethod` and preserve Cloud/Data Center behavior.
+3. Validate from repo root with `./Tools/setup.ps1` then `Invoke-Build -Task Build, Test`.
+4. This repo may have no `Tests/`; validation can warn/skip tests—report exact outcomes.
+5. Public function sources are unprefixed (for example `Get-Board`) and exported with `JiraAgile` prefix.
+
+## File Locations
+
+- Public functions: `JiraAgilePS/Public/`
+- Private functions: `JiraAgilePS/Private/`
+- Tests (optional legacy coverage): `Tests/` (copied to `Release/Tests/` when present)
+- Docs/help sources: `docs/en-US/commands/` (add files when command help changes)

--- a/.github/instructions/jiraagile-api-compatibility.instructions.md
+++ b/.github/instructions/jiraagile-api-compatibility.instructions.md
@@ -1,0 +1,20 @@
+---
+applyTo: "**/*.ps1"
+---
+
+# PowerShell File Rules (GitHub Copilot)
+
+This file applies to all `.ps1` files. It references shared rules.
+
+**Canonical source**: [.github/ai-context/powershell-rules.md](../ai-context/powershell-rules.md)
+
+## Quick Reference
+
+1. **Cloud AND Data Center** — keep Jira Agile behavior compatible unless the task explicitly scopes one deployment type.
+2. **Supported API tracks** — validate Agile endpoint/field changes against both Cloud and Data Center/Server references.
+3. **Agile REST surface** — this module uses Jira Agile `/rest/agile/1.0` endpoints; avoid Jira Core-only assumptions.
+4. **REST calls** — route command-level HTTP interactions through `Invoke-JiraMethod`.
+5. **Tests required** — during iteration run targeted `Invoke-Pester` when tests exist (for example `Invoke-Pester -Path 'Tests/Functions/Public/Get-Board.Unit.Tests.ps1'`).
+6. **Final validation** — run `./Tools/setup.ps1` and `Invoke-Build -Task Build, Test`; if tests are absent/warn-skipped, report exact outcomes.
+
+For full rules, read `.github/ai-context/powershell-rules.md`.

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 # except for git files
 !.devcontainer/
 !.github/
+!.cursor/
 !.vscode/
 !.editorconfig
 !.gitattributes

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,77 @@
+# AI Instructions for JiraAgilePS
+
+> **Single source of truth for AI coding assistants.**
+> Tool-specific entry-point files in this repository reference this file.
+
+## Quick Reference (Critical Rules)
+
+1. **Keep changes focused**: scope each commit/PR to one behavior; include tests, docs, and changelog updates when impacted and available.
+2. **Always attempt repo validation**: run `./Tools/setup.ps1` and `Invoke-Build -Task Build, Test` from repo root before finalizing.
+3. **Use shared Jira transport**: route Jira API calls through `Invoke-JiraMethod`.
+4. **Preserve compatibility**: keep Jira Cloud/Data Center Agile behavior stable unless the change explicitly targets compatibility behavior.
+5. **Do not overstate coverage**: this repo may have no `Tests/` folder; report skipped/failing validation clearly instead of claiming full test coverage.
+6. **Keep user-facing docs aligned**: update `docs/en-US/commands/*.md` (or add missing command pages when needed) and `CHANGELOG.md` for visible behavior changes.
+
+## AI Tool Compatibility
+
+| Tool | Entry point | Canonical references |
+|------|-------------|----------------------|
+| GitHub Copilot | `.github/copilot-instructions.md` | `AGENTS.md`, `.github/ai-context/powershell-rules.md` |
+| Cursor | `.cursor/rules/jiraagileps.mdc` | `AGENTS.md`, `.github/ai-context/powershell-rules.md` |
+| Claude Code | `CLAUDE.md` | `AGENTS.md`, `.github/ai-context/powershell-rules.md` |
+| Gemini/Antigravity | `GEMINI.md` | `AGENTS.md`, `.github/ai-context/powershell-rules.md` |
+
+## Project Overview
+
+`JiraAgilePS` adds Jira Agile cmdlets on top of JiraPS.
+The repository is older and currently has less mature automated test coverage than JiraPS.
+
+## Architecture
+
+- Module source: `JiraAgilePS/Public/` and `JiraAgilePS/Private/`
+- Public function files use unprefixed names (for example `Get-Board`) and are exported with manifest `DefaultCommandPrefix = 'JiraAgile'`.
+- Build entrypoint: `JiraAgilePS.build.ps1`
+- Docs/help sources: `docs/en-US/`
+- Build helpers: `Tools/`
+- Optional tests source: `Tests/` (copied to `Release/Tests/` by `PrepareTests` when present)
+
+## Coding Standards
+
+- Follow existing cmdlet patterns and avoid broad refactors in focused fixes.
+- Prefer extending existing helpers/converters over duplicate logic.
+- Keep comments minimal and high-value.
+- Use `#ToDo:<Category>` for actionable technical debt markers.
+- Remove dead code instead of leaving commented-out blocks.
+
+## Build and Test
+
+```powershell
+./Tools/setup.ps1
+Invoke-Build -Task Build, Test
+```
+
+Notes for this repository's current legacy state:
+
+- `Invoke-Build -Task Test` runs from `Release/Tests/` and currently warns/skips when no test files are found.
+- If validation fails in `Build`/`Test`, capture the exact failing task and error; do not report validation as passed.
+- Use focused `Invoke-Pester` runs when test files are present.
+
+## CI/CD
+
+- `ci.yml` runs on `master` push/PR and executes build + matrix tests (Windows PS5/PS7, Ubuntu, macOS).
+- `release.yml` handles tagged releases (`v*`) and consumes the `Release` artifact produced by `ci.yml` for the tagged commit.
+- Keep workflow assumptions aligned with this flow when updating instructions or build logic.
+
+## When Working on This Project
+
+### Do
+
+- Keep backward compatibility for existing cmdlet parameters and output shapes.
+- Add regression tests when fixing bugs.
+- Keep changelog entries concise and user-oriented.
+
+### Do not
+
+- Bypass `Invoke-JiraMethod` in command implementations.
+- Introduce unrelated modernization changes in feature-specific branches.
+- Add new runtime dependencies without strong justification.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,17 +6,19 @@
 ## Quick Reference (Critical Rules)
 
 1. **Keep changes focused**: scope each commit/PR to one behavior; include tests, docs, and changelog updates when impacted and available.
-2. **Always attempt repo validation**: run `./Tools/setup.ps1` and `Invoke-Build -Task Build, Test` from repo root before finalizing.
-3. **Use shared Jira transport**: route Jira API calls through `Invoke-JiraMethod`.
-4. **Preserve compatibility**: keep Jira Cloud/Data Center Agile behavior stable unless the change explicitly targets compatibility behavior.
-5. **Do not overstate coverage**: this repo may have no `Tests/` folder; report skipped/failing validation clearly instead of claiming full test coverage.
-6. **Keep user-facing docs aligned**: update `docs/en-US/commands/*.md` (or add missing command pages when needed) and `CHANGELOG.md` for visible behavior changes.
+2. **Use the right test loop**: during iteration, run targeted `Invoke-Pester` when relevant test files exist (for example `Invoke-Pester -Path 'Tests/Functions/Public/Get-Board.Unit.Tests.ps1'`).
+3. **Always attempt repo validation before finalizing**: run `./Tools/setup.ps1` and `Invoke-Build -Task Build, Test` from repo root.
+4. **Use shared Jira transport**: route Jira API calls through `Invoke-JiraMethod`.
+5. **Preserve compatibility**: keep Jira Cloud/Data Center Agile behavior stable unless the change explicitly targets compatibility behavior.
+6. **Do not overstate coverage**: this repo may have no `Tests/` folder; report skipped/failing validation clearly instead of claiming full test coverage.
+7. **Keep user-facing docs aligned**: update `docs/en-US/commands/*.md` (or add missing command pages when needed) and `CHANGELOG.md` for visible behavior changes.
 
 ## AI Tool Compatibility
 
 | Tool | Entry point | Canonical references |
 |------|-------------|----------------------|
 | GitHub Copilot | `.github/copilot-instructions.md` | `AGENTS.md`, `.github/ai-context/powershell-rules.md` |
+| GitHub Copilot (file rules) | `.github/instructions/jiraagile-api-compatibility.instructions.md` | `.github/ai-context/powershell-rules.md` |
 | Cursor | `.cursor/rules/jiraagileps.mdc` | `AGENTS.md`, `.github/ai-context/powershell-rules.md` |
 | Claude Code | `CLAUDE.md` | `AGENTS.md`, `.github/ai-context/powershell-rules.md` |
 | Gemini/Antigravity | `GEMINI.md` | `AGENTS.md`, `.github/ai-context/powershell-rules.md` |
@@ -54,7 +56,13 @@ Notes for this repository's current legacy state:
 
 - `Invoke-Build -Task Test` runs from `Release/Tests/` and currently warns/skips when no test files are found.
 - If validation fails in `Build`/`Test`, capture the exact failing task and error; do not report validation as passed.
-- Use focused `Invoke-Pester` runs when test files are present.
+- During iteration, use focused `Invoke-Pester` runs when test files are present (for example `Invoke-Pester -Path 'Tests/Functions/Public/Get-Board.Unit.Tests.ps1'`).
+
+## Supported API Reference Tracks (Cloud + Data Center)
+
+- Cloud track (Jira Software REST): https://developer.atlassian.com/cloud/jira/software/rest/
+- Data Center/Server track (Jira Software REST): https://docs.atlassian.com/jira-software/REST/latest/
+- Before adopting or changing Agile endpoints/fields, verify behavior against both tracks unless the task is explicitly Cloud-only or Data Center-only.
 
 ## CI/CD
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,21 @@
+# Claude Code Entry Point
+
+Read this first, then follow canonical sources:
+
+- Project rules: [AGENTS.md](AGENTS.md)
+- PowerShell rules: [.github/ai-context/powershell-rules.md](.github/ai-context/powershell-rules.md)
+
+## Quick Reference
+
+1. Scope each change to one behavior; update tests/docs/changelog when impacted and available.
+2. Route Jira API interactions through `Invoke-JiraMethod` and preserve Cloud/Data Center behavior.
+3. Validate from repo root with `./Tools/setup.ps1` then `Invoke-Build -Task Build, Test`.
+4. This repo may have no `Tests/`; validation can warn/skip tests—report exact outcomes.
+5. Public function sources are unprefixed (for example `Get-Board`) and exported with `JiraAgile` prefix.
+
+## File Locations
+
+- Public functions: `JiraAgilePS/Public/`
+- Private functions: `JiraAgilePS/Private/`
+- Tests (optional legacy coverage): `Tests/` (copied to `Release/Tests/` when present)
+- Docs/help sources: `docs/en-US/commands/` (add files when command help changes)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,9 +9,10 @@ Read this first, then follow canonical sources:
 
 1. Scope each change to one behavior; update tests/docs/changelog when impacted and available.
 2. Route Jira API interactions through `Invoke-JiraMethod` and preserve Cloud/Data Center behavior.
-3. Validate from repo root with `./Tools/setup.ps1` then `Invoke-Build -Task Build, Test`.
-4. This repo may have no `Tests/`; validation can warn/skip tests—report exact outcomes.
-5. Public function sources are unprefixed (for example `Get-Board`) and exported with `JiraAgile` prefix.
+3. During iteration, run targeted tests when present (for example `Invoke-Pester -Path 'Tests/Functions/Public/Get-Board.Unit.Tests.ps1'`).
+4. Before finalizing, validate from repo root with `./Tools/setup.ps1` then `Invoke-Build -Task Build, Test`.
+5. This repo may have no `Tests/`; validation can warn/skip tests—report exact outcomes.
+6. Public function sources are unprefixed (for example `Get-Board`) and exported with `JiraAgile` prefix.
 
 ## File Locations
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -9,9 +9,10 @@ Read this file first, then follow canonical sources:
 
 1. Scope each change to one behavior; update tests/docs/changelog when impacted and available.
 2. Route Jira API interactions through `Invoke-JiraMethod` and preserve Cloud/Data Center behavior.
-3. Validate from repo root with `./Tools/setup.ps1` then `Invoke-Build -Task Build, Test`.
-4. This repo may have no `Tests/`; validation can warn/skip tests—report exact outcomes.
-5. Public function sources are unprefixed (for example `Get-Board`) and exported with `JiraAgile` prefix.
+3. During iteration, run targeted tests when present (for example `Invoke-Pester -Path 'Tests/Functions/Public/Get-Board.Unit.Tests.ps1'`).
+4. Before finalizing, validate from repo root with `./Tools/setup.ps1` then `Invoke-Build -Task Build, Test`.
+5. This repo may have no `Tests/`; validation can warn/skip tests—report exact outcomes.
+6. Public function sources are unprefixed (for example `Get-Board`) and exported with `JiraAgile` prefix.
 
 ## File Locations
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,0 +1,21 @@
+# Gemini/Antigravity Entry Point
+
+Read this file first, then follow canonical sources:
+
+- Project rules: [AGENTS.md](AGENTS.md)
+- PowerShell rules: [.github/ai-context/powershell-rules.md](.github/ai-context/powershell-rules.md)
+
+## Quick Reference
+
+1. Scope each change to one behavior; update tests/docs/changelog when impacted and available.
+2. Route Jira API interactions through `Invoke-JiraMethod` and preserve Cloud/Data Center behavior.
+3. Validate from repo root with `./Tools/setup.ps1` then `Invoke-Build -Task Build, Test`.
+4. This repo may have no `Tests/`; validation can warn/skip tests—report exact outcomes.
+5. Public function sources are unprefixed (for example `Get-Board`) and exported with `JiraAgile` prefix.
+
+## File Locations
+
+- Public functions: `JiraAgilePS/Public/`
+- Private functions: `JiraAgilePS/Private/`
+- Tests (optional legacy coverage): `Tests/` (copied to `Release/Tests/` when present)
+- Docs/help sources: `docs/en-US/commands/` (add files when command help changes)


### PR DESCRIPTION
## Summary
- add canonical AGENTS.md and tool entrypoint instruction files
- add Copilot file-pattern instruction rules at `.github/instructions/jiraagile-api-compatibility.instructions.md`
- strengthen test-loop guidance across entrypoints: targeted `Invoke-Pester` during iteration (when tests exist) and full `Invoke-Build -Task Build, Test` before finalization
- add explicit supported API reference tracks for Jira Software Cloud and Data Center/Server
- preserve legacy-safe validation/reporting guidance for repositories with sparse test coverage

## Validation
- `./Tools/setup.ps1`
- `Invoke-Build -Task Build, Test` *(local baseline currently fails at `BuildHelpers\Update-Metadata` in `UpdateManifest`)*

## Notes
- CI checks for this PR are green; local baseline failure above is an existing repo issue and not introduced by this instruction-only change.
- This PR updates instructions only and does not change runtime cmdlet behavior.