### PR TITLE
Fix core JiraAgilePS cmdlet defects

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,10 +68,12 @@ jobs:
 
       - name: Upload unit test results
         if: always()
-        uses: actions/upload-artifact@v7
+        continue-on-error: true
+        uses: actions/upload-artifact@v8
         with:
           name: Windows-PS5-Unit-Tests
           path: Test*.xml
+          overwrite: true
 
   test_pwsh:
     name: Test (${{ matrix.name }})
@@ -100,10 +102,12 @@ jobs:
 
       - name: Upload unit test results
         if: always()
-        uses: actions/upload-artifact@v7
+        continue-on-error: true
+        uses: actions/upload-artifact@v8
         with:
           name: ${{ matrix.name }}-Unit-Tests
           path: Test*.xml
+          overwrite: true
 
   ci-required:
     name: CI Result

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,12 +68,10 @@ jobs:
 
       - name: Upload unit test results
         if: always()
-        continue-on-error: true
         uses: actions/upload-artifact@v7
         with:
           name: Windows-PS5-Unit-Tests
           path: Test*.xml
-          overwrite: true
 
   test_pwsh:
     name: Test (${{ matrix.name }})
@@ -102,12 +100,10 @@ jobs:
 
       - name: Upload unit test results
         if: always()
-        continue-on-error: true
         uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.name }}-Unit-Tests
           path: Test*.xml
-          overwrite: true
 
   ci-required:
     name: CI Result

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
       - name: Upload unit test results
         if: always()
         continue-on-error: true
-        uses: actions/upload-artifact@v8
+        uses: actions/upload-artifact@v7
         with:
           name: Windows-PS5-Unit-Tests
           path: Test*.xml
@@ -103,7 +103,7 @@ jobs:
       - name: Upload unit test results
         if: always()
         continue-on-error: true
-        uses: actions/upload-artifact@v8
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.name }}-Unit-Tests
           path: Test*.xml

--- a/JiraAgilePS/Public/Add-IssueToSprint.ps1
+++ b/JiraAgilePS/Public/Add-IssueToSprint.ps1
@@ -39,7 +39,7 @@ function Add-IssueToSprint {
     end {
         while ($issuesToProcess.Count -gt 0) {
             $thisPageSize = if ($issuesToProcess.Count -lt 50) { $issuesToProcess.Count } else { 50 }
-            $thisIssuePage = Select-Object -InputObject $issuesToProcess -First $thisPageSize
+            $thisIssuePage = @($issuesToProcess | Select-Object -First $thisPageSize)
 
             $requestParameter = @{
                 Uri        = "$($Sprint.Self)/issue"

--- a/JiraAgilePS/Public/Get-Board.ps1
+++ b/JiraAgilePS/Public/Get-Board.ps1
@@ -55,7 +55,7 @@ function Get-Board {
                     Write-Verbose "[$($MyInvocation.MyCommand.Name)] Processing [$_boardId]"
                     Write-Debug "[$($MyInvocation.MyCommand.Name)] Processing `$_boardId [$_boardId]"
 
-                    $requestParameter['Uri'] += "$resourceUrl/$_boardId"
+                    $requestParameter['Uri'] = "$resourceUrl/$_boardId"
                     $requestParameter['Paging'] = $false
 
                     Write-Debug "[$($MyInvocation.MyCommand.Name)] Invoking JiraMethod with `$requestParameter"

--- a/JiraAgilePS/Public/Get-Sprint.ps1
+++ b/JiraAgilePS/Public/Get-Sprint.ps1
@@ -66,7 +66,7 @@ function Get-Sprint {
             }
             '_ById' {
                 foreach ($_sprint in $Sprint) {
-                    $requestParameter["Uri"] = $resourceUrl_ById -f $Sprint.Id
+                    $requestParameter["Uri"] = $resourceUrl_ById -f $_sprint.Id
                     $requestParameter["GetParameter"] = @{ }
                     $requestParameter["Paging"] = $false
 

--- a/Tests/Functions/Public/Add-IssueToSprint.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Add-IssueToSprint.Unit.Tests.ps1
@@ -98,6 +98,10 @@ InModuleScope JiraAgilePS {
                 { Add-JiraAgileIssueToSprint -Issue $issues -Sprint $sprint } | Should -Not -Throw
 
                 Should -Invoke -CommandName Invoke-JiraMethod -ModuleName JiraAgilePS -Exactly -Times 2 -Scope It
+                Should -Invoke -CommandName Invoke-JiraMethod -ModuleName JiraAgilePS -Exactly -Times 2 -Scope It -ParameterFilter {
+                    $Method -eq "POST" -and
+                    $Uri -eq "$sprintUri/issue"
+                }
 
                 $firstBodyIssues = ($script:postedBodies[0] | ConvertFrom-Json).issues
                 $secondBodyIssues = ($script:postedBodies[1] | ConvertFrom-Json).issues

--- a/Tests/Functions/Public/Add-IssueToSprint.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Add-IssueToSprint.Unit.Tests.ps1
@@ -14,6 +14,8 @@ InModuleScope JiraAgilePS {
         }
 
         BeforeEach {
+            $script:postedBodies = [System.Collections.Generic.List[string]]::new()
+
             Mock Get-Sprint -ModuleName JiraAgilePS {
                 [AtlassianPS.JiraAgilePS.Sprint]@{
                     Id   = 99
@@ -23,6 +25,7 @@ InModuleScope JiraAgilePS {
 
             Mock Invoke-JiraMethod -ModuleName JiraAgilePS {
                 param($Uri, $Method, $Body)
+                $null = $script:postedBodies.Add($Body)
             }
         }
 
@@ -85,6 +88,27 @@ InModuleScope JiraAgilePS {
 
                 Should -Invoke -CommandName Get-Sprint -ModuleName JiraAgilePS -Exactly -Times 1 -Scope It
                 Should -Invoke -CommandName Invoke-JiraMethod -ModuleName JiraAgilePS -Exactly -Times 1 -Scope It
+            }
+
+            It "sends sprint issue payloads in pages of 50 issue keys" {
+                $sprint = [AtlassianPS.JiraAgilePS.Sprint]::new(99)
+                $sprint.Self = [Uri]$sprintUri
+                $issues = @(1..55 | ForEach-Object { [pscustomobject]@{ Key = "AG-$_" } })
+
+                { Add-JiraAgileIssueToSprint -Issue $issues -Sprint $sprint } | Should -Not -Throw
+
+                Should -Invoke -CommandName Invoke-JiraMethod -ModuleName JiraAgilePS -Exactly -Times 2 -Scope It
+
+                $firstBodyIssues = ($script:postedBodies[0] | ConvertFrom-Json).issues
+                $secondBodyIssues = ($script:postedBodies[1] | ConvertFrom-Json).issues
+
+                @($firstBodyIssues).Count | Should -Be 50
+                $firstBodyIssues[0] | Should -Be "AG-1"
+                $firstBodyIssues[-1] | Should -Be "AG-50"
+
+                @($secondBodyIssues).Count | Should -Be 5
+                $secondBodyIssues[0] | Should -Be "AG-51"
+                $secondBodyIssues[-1] | Should -Be "AG-55"
             }
         }
     }

--- a/Tests/Functions/Public/Get-Board.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Get-Board.Unit.Tests.ps1
@@ -83,6 +83,31 @@ InModuleScope JiraAgilePS {
                 $result.Id | Should -Be 7
                 $result.Name | Should -Be "Target board"
             }
+
+            It "requests each board id with an independent URI when multiple ids are supplied" {
+                Mock Invoke-JiraMethod -ModuleName JiraAgilePS {
+                    [pscustomobject]@{
+                        Id   = 7
+                        Name = "Target board"
+                        Type = "kanban"
+                        Self = "$jiraServer/rest/agile/1.0/board/7"
+                    }
+                }
+
+                $null = Get-JiraAgileBoard -BoardId 7, 8
+
+                Should -Invoke -CommandName Invoke-JiraMethod -ModuleName JiraAgilePS -Exactly -Times 2 -Scope It
+                Should -Invoke -CommandName Invoke-JiraMethod -ModuleName JiraAgilePS -Exactly -Times 1 -Scope It -ParameterFilter {
+                    $Method -eq "GET" -and
+                    $Uri -eq "$jiraServer/rest/agile/1.0/board/7" -and
+                    (-not $Paging)
+                }
+                Should -Invoke -CommandName Invoke-JiraMethod -ModuleName JiraAgilePS -Exactly -Times 1 -Scope It -ParameterFilter {
+                    $Method -eq "GET" -and
+                    $Uri -eq "$jiraServer/rest/agile/1.0/board/8" -and
+                    (-not $Paging)
+                }
+            }
         }
     }
 }

--- a/Tests/Functions/Public/Get-Sprint.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Get-Sprint.Unit.Tests.ps1
@@ -100,22 +100,25 @@ InModuleScope JiraAgilePS {
 
             It "requests each sprint id independently when multiple sprints are supplied" {
                 Mock Invoke-JiraMethod -ModuleName JiraAgilePS {
+                    param($Uri)
+                    $sprintId = [int]($Uri -replace "^.*/", "")
+
                     [pscustomobject]@{
-                        Id            = 21
-                        Name          = "Sprint 21"
+                        Id            = $sprintId
+                        Name          = "Sprint $sprintId"
                         State         = "future"
                         startDate     = "2026-02-01T00:00:00.000Z"
                         endDate       = "2026-02-14T00:00:00.000Z"
                         completeDate  = $null
                         OriginBoardId = 4
                         Goal          = "Prepare"
-                        Self          = "$jiraServer/rest/agile/1.0/sprint/21"
+                        Self          = "$jiraServer/rest/agile/1.0/sprint/$sprintId"
                     }
                 }
                 $sprintA = [AtlassianPS.JiraAgilePS.Sprint]::new(21)
                 $sprintB = [AtlassianPS.JiraAgilePS.Sprint]::new(22)
 
-                $null = Get-JiraAgileSprint -Sprint @($sprintA, $sprintB)
+                $result = Get-JiraAgileSprint -Sprint @($sprintA, $sprintB)
 
                 Should -Invoke -CommandName Invoke-JiraMethod -ModuleName JiraAgilePS -Exactly -Times 2 -Scope It
                 Should -Invoke -CommandName Invoke-JiraMethod -ModuleName JiraAgilePS -Exactly -Times 1 -Scope It -ParameterFilter {
@@ -128,6 +131,9 @@ InModuleScope JiraAgilePS {
                     $Uri -eq "$jiraServer/rest/agile/1.0/sprint/22" -and
                     (-not $Paging)
                 }
+                @($result).Count | Should -Be 2
+                (@($result | Select-Object -ExpandProperty Id) -join ",") | Should -Be "21,22"
+                (@($result | Select-Object -ExpandProperty Name) -join ",") | Should -Be "Sprint 21,Sprint 22"
             }
         }
     }

--- a/Tests/Functions/Public/Get-Sprint.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Get-Sprint.Unit.Tests.ps1
@@ -97,6 +97,38 @@ InModuleScope JiraAgilePS {
                 $result.Id | Should -Be 21
                 $result.Name | Should -Be "Sprint 21"
             }
+
+            It "requests each sprint id independently when multiple sprints are supplied" {
+                Mock Invoke-JiraMethod -ModuleName JiraAgilePS {
+                    [pscustomobject]@{
+                        Id            = 21
+                        Name          = "Sprint 21"
+                        State         = "future"
+                        startDate     = "2026-02-01T00:00:00.000Z"
+                        endDate       = "2026-02-14T00:00:00.000Z"
+                        completeDate  = $null
+                        OriginBoardId = 4
+                        Goal          = "Prepare"
+                        Self          = "$jiraServer/rest/agile/1.0/sprint/21"
+                    }
+                }
+                $sprintA = [AtlassianPS.JiraAgilePS.Sprint]::new(21)
+                $sprintB = [AtlassianPS.JiraAgilePS.Sprint]::new(22)
+
+                $null = Get-JiraAgileSprint -Sprint @($sprintA, $sprintB)
+
+                Should -Invoke -CommandName Invoke-JiraMethod -ModuleName JiraAgilePS -Exactly -Times 2 -Scope It
+                Should -Invoke -CommandName Invoke-JiraMethod -ModuleName JiraAgilePS -Exactly -Times 1 -Scope It -ParameterFilter {
+                    $Method -eq "GET" -and
+                    $Uri -eq "$jiraServer/rest/agile/1.0/sprint/21" -and
+                    (-not $Paging)
+                }
+                Should -Invoke -CommandName Invoke-JiraMethod -ModuleName JiraAgilePS -Exactly -Times 1 -Scope It -ParameterFilter {
+                    $Method -eq "GET" -and
+                    $Uri -eq "$jiraServer/rest/agile/1.0/sprint/22" -and
+                    (-not $Paging)
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- fix Get-JiraAgileBoard URI handling so multiple BoardId values do not produce malformed URIs
- fix Get-JiraAgileSprint URI handling so each sprint in multi-item input uses its own id
- fix Add-JiraAgileIssueToSprint paging selection so batched payloads contain the correct issue keys
- add regression unit tests for multi-item URI construction and 50-item payload paging behavior

Fixes #12