### PR TITLE
Add practical JiraAgilePS command documentation

### DIFF
--- a/docs/en-US/commands/Add-IssueToSprint.md
+++ b/docs/en-US/commands/Add-IssueToSprint.md
@@ -1,0 +1,86 @@
+---
+external help file: JiraAgilePS-help.xml
+Module Name: JiraAgilePS
+online version: https://atlassianps.org/docs/JiraAgilePS/commands/Add-IssueToSprint/
+locale: en-US
+layout: documentation
+permalink: /docs/JiraAgilePS/commands/Add-IssueToSprint/
+---
+# Add-IssueToSprint
+
+## SYNOPSIS
+
+Adds one or more Jira issues to a sprint.
+
+## SYNTAX
+
+```powershell
+Add-IssueToSprint [-Issue] <Object> [-Sprint] <Sprint> [-Credential <PSCredential>] [<CommonParameters>]
+```
+
+## DESCRIPTION
+
+`Add-IssueToSprint` assigns Jira issues to a target sprint.
+
+If the supplied sprint object is incomplete, the command resolves it first and then submits issue keys in request batches.
+
+## EXAMPLES
+
+### EXAMPLE 1
+
+```powershell
+$board  = JiraAgilePS\Get-Board -Credential $cred | Select-Object -First 1
+$sprint = JiraAgilePS\Get-Sprint -Board $board -State Active -Credential $cred | Select-Object -First 1
+$issue  = Get-JiraIssue -Issue "PROJ-123" -Credential $cred
+
+JiraAgilePS\Add-IssueToSprint -Issue $issue -Sprint $sprint -Credential $cred
+```
+
+Adds one Jira issue to the active sprint.
+
+### EXAMPLE 2
+
+```powershell
+$issues = @(
+    Get-JiraIssue -Issue "PROJ-123" -Credential $cred
+    Get-JiraIssue -Issue "PROJ-124" -Credential $cred
+)
+
+JiraAgilePS\Add-IssueToSprint -Issue $issues -Sprint $sprint -Credential $cred
+```
+
+Adds multiple issues to a sprint.
+
+## PARAMETERS
+
+### -Issue
+
+Issue object(s) to add to the sprint.
+
+### -Sprint
+
+Target sprint object.
+
+### -Credential
+
+Credentials used for Jira authentication.
+
+## INPUTS
+
+### System.Object
+
+Issue object(s) from JiraPS commands, for example `Get-JiraIssue`.
+
+## OUTPUTS
+
+### System.Void
+
+## NOTES
+
+This command does not emit output on success.
+
+## RELATED LINKS
+
+[Get-Board](Get-Board.html)
+
+[Get-Sprint](Get-Sprint.html)

--- a/docs/en-US/commands/Get-Board.md
+++ b/docs/en-US/commands/Get-Board.md
@@ -1,0 +1,82 @@
+---
+external help file: JiraAgilePS-help.xml
+Module Name: JiraAgilePS
+online version: https://atlassianps.org/docs/JiraAgilePS/commands/Get-Board/
+locale: en-US
+layout: documentation
+permalink: /docs/JiraAgilePS/commands/Get-Board/
+---
+# Get-Board
+
+## SYNOPSIS
+
+Gets Jira Agile boards.
+
+## SYNTAX
+
+### _All (Default)
+
+```powershell
+Get-Board [[-PageSize] <UInt32>] [-Credential <PSCredential>] [<CommonParameters>]
+```
+
+### _Search
+
+```powershell
+Get-Board [-BoardId] <UInt64[]> [[-PageSize] <UInt32>] [-Credential <PSCredential>] [<CommonParameters>]
+```
+
+## DESCRIPTION
+
+`Get-Board` queries Jira Agile boards through the Jira Agile REST API.
+
+Use `-BoardId` when you already know specific board identifiers.  
+Without `-BoardId`, the command returns boards with paging support.
+
+## EXAMPLES
+
+### EXAMPLE 1
+
+```powershell
+JiraAgilePS\Get-Board -Credential $cred
+```
+
+Returns boards visible to the authenticated user.
+
+### EXAMPLE 2
+
+```powershell
+JiraAgilePS\Get-Board -BoardId 12, 45 -Credential $cred
+```
+
+Returns only the boards with IDs 12 and 45.
+
+## PARAMETERS
+
+### -BoardId
+
+One or more board IDs to retrieve.
+
+### -PageSize
+
+Maximum results requested per page when listing boards.
+
+### -Credential
+
+Credentials used for Jira authentication.
+
+## INPUTS
+
+### System.UInt64[]
+
+Board IDs when using the `_Search` parameter set.
+
+## OUTPUTS
+
+### AtlassianPS.JiraAgilePS.Board
+
+## RELATED LINKS
+
+[Get-Sprint](Get-Sprint.html)
+
+[Add-IssueToSprint](Add-IssueToSprint.html)

--- a/docs/en-US/commands/Get-Sprint.md
+++ b/docs/en-US/commands/Get-Sprint.md
@@ -1,0 +1,98 @@
+---
+external help file: JiraAgilePS-help.xml
+Module Name: JiraAgilePS
+online version: https://atlassianps.org/docs/JiraAgilePS/commands/Get-Sprint/
+locale: en-US
+layout: documentation
+permalink: /docs/JiraAgilePS/commands/Get-Sprint/
+---
+# Get-Sprint
+
+## SYNOPSIS
+
+Gets sprint data from Jira Agile.
+
+## SYNTAX
+
+### _All (Default)
+
+```powershell
+Get-Sprint [-Board] <Board> [[-State] <SprintState>] [[-PageSize] <UInt32>] [-Credential <PSCredential>] [<CommonParameters>]
+```
+
+### _ById
+
+```powershell
+Get-Sprint [-Sprint] <Sprint[]> [-Credential <PSCredential>] [<CommonParameters>]
+```
+
+## DESCRIPTION
+
+`Get-Sprint` retrieves sprints either:
+
+- by board (optionally filtered by state), or
+- by known sprint object/ID context.
+
+When called with `-Board`, the command supports paging and can return all matching sprints.
+
+## EXAMPLES
+
+### EXAMPLE 1
+
+```powershell
+$board = JiraAgilePS\Get-Board -Credential $cred | Select-Object -First 1
+JiraAgilePS\Get-Sprint -Board $board -Credential $cred
+```
+
+Lists sprints for a board.
+
+### EXAMPLE 2
+
+```powershell
+$board = JiraAgilePS\Get-Board -Credential $cred | Select-Object -First 1
+JiraAgilePS\Get-Sprint -Board $board -State Active -Credential $cred
+```
+
+Returns only active sprints for the selected board.
+
+## PARAMETERS
+
+### -Sprint
+
+Sprint object(s) used when querying by sprint identity.
+
+### -Board
+
+Board object used to retrieve board sprints.
+
+### -State
+
+Optional sprint state filter (for example `Active`).
+
+### -PageSize
+
+Maximum results requested per page when listing board sprints.
+
+### -Credential
+
+Credentials used for Jira authentication.
+
+## INPUTS
+
+### AtlassianPS.JiraAgilePS.Board
+
+Board object when using the `_All` parameter set.
+
+### AtlassianPS.JiraAgilePS.Sprint[]
+
+Sprint object(s) when using the `_ById` parameter set.
+
+## OUTPUTS
+
+### AtlassianPS.JiraAgilePS.Sprint
+
+## RELATED LINKS
+
+[Get-Board](Get-Board.html)
+
+[Add-IssueToSprint](Add-IssueToSprint.html)

--- a/docs/en-US/commands/index.md
+++ b/docs/en-US/commands/index.md
@@ -3,3 +3,12 @@ layout: documentation
 permalink: /docs/JiraAgilePS/commands/
 hide: true
 ---
+# JiraAgilePS commands
+
+JiraAgilePS currently provides three commands focused on boards and sprints:
+
+- [Get-Board](Get-Board.html)
+- [Get-Sprint](Get-Sprint.html)
+- [Add-IssueToSprint](Add-IssueToSprint.html)
+
+For module overview and setup, see [about_JiraAgilePS](/docs/JiraAgilePS/).

--- a/docs/en-US/index.md
+++ b/docs/en-US/index.md
@@ -1,5 +1,46 @@
 ---
+Module Name: JiraAgilePS
+online version: https://atlassianps.org/docs/JiraAgilePS/
+locale: en-US
 layout: documentation
-permalink: /docs/JiraAgilePS/about/
+permalink: /docs/JiraAgilePS/
 hide: true
 ---
+# JiraAgilePS
+
+## about_JiraAgilePS
+
+# SHORT DESCRIPTION
+
+JiraAgilePS extends JiraPS with Atlassian Jira Agile board and sprint operations.
+
+# LONG DESCRIPTION
+
+Use JiraAgilePS when you need to automate board and sprint workflows from PowerShell.
+It relies on JiraPS connectivity and session configuration, then adds Agile-specific commands.
+
+The module currently includes:
+
+- `Get-Board`
+- `Get-Sprint`
+- `Add-IssueToSprint`
+
+## GETTING STARTED
+
+```powershell
+Import-Module JiraPS
+Import-Module JiraAgilePS
+
+Set-JiraConfigServer "https://yourcompany.atlassian.net"
+$cred = Get-Credential
+New-JiraSession -Credential $cred
+
+JiraAgilePS\Get-Board -Credential $cred
+```
+
+## SEE ALSO
+
+- [Get-Board](commands/Get-Board.html)
+- [Get-Sprint](commands/Get-Sprint.html)
+- [Add-IssueToSprint](commands/Add-IssueToSprint.html)
+- [Source repository](https://github.com/AtlassianPS/JiraAgilePS)


### PR DESCRIPTION
Publishes usable module-native docs in JiraAgilePS so the website can consume canonical content.

## What is included
- fills `docs/en-US/index.md` with module overview and quick-start
- fills `docs/en-US/commands/index.md` with command map
- adds command docs for:
  - `Get-Board`
  - `Get-Sprint`
  - `Add-IssueToSprint`

## Validation
- `Invoke-Build -Task Build, Test` (passes)
- external help generation succeeds from updated markdown docs