### PR TITLE
Add JiraAgilePS transformers for Board/Sprint/Epic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 ### Changed
 
 - Harmonized integration test environment setup with JiraPS by adopting `.env.example` and a shared-style `.env` loader/validator in `Tests/Helpers/IntegrationTestTools.ps1`.
+- Added JiraPS-style argument transformers for JiraAgilePS `Board`, `Sprint`, and `Epic` classes so cmdlets accept identifiers (for example numeric IDs) directly where typed class parameters are used.
 
 ### Fixed
 

--- a/JiraAgilePS/JiraAgilePS.Types.cs
+++ b/JiraAgilePS/JiraAgilePS.Types.cs
@@ -21,6 +21,393 @@ namespace AtlassianPS
             closed
         }
 
+        internal static class JiraAgileTransform
+        {
+            public static bool IsNumericType(object value)
+            {
+                return value is int || value is long || value is short || value is byte
+                    || value is uint || value is ulong || value is ushort || value is sbyte;
+            }
+
+            public static bool TryConvertToUInt64(object value, out UInt64 result)
+            {
+                result = 0;
+                if (value == null) { return false; }
+
+                if (value is UInt64)
+                {
+                    result = (UInt64)value;
+                    return true;
+                }
+
+                if (IsNumericType(value))
+                {
+                    try
+                    {
+                        var signedValue = Convert.ToInt64(value);
+                        if (signedValue < 0) { return false; }
+                        result = (UInt64)signedValue;
+                        return true;
+                    }
+                    catch
+                    {
+                        return false;
+                    }
+                }
+
+                UInt64 parsed;
+                if (UInt64.TryParse(value.ToString(), out parsed))
+                {
+                    result = parsed;
+                    return true;
+                }
+
+                return false;
+            }
+
+            public static bool IsJiraAgileDomainObject(object value)
+            {
+                if (value == null) { return false; }
+
+                var pso = value as PSObject;
+                if (pso != null)
+                {
+                    if (pso.TypeNames != null)
+                    {
+                        foreach (var typeName in pso.TypeNames)
+                        {
+                            if (!string.IsNullOrEmpty(typeName)
+                                && typeName.StartsWith("AtlassianPS.JiraAgilePS.", StringComparison.Ordinal))
+                            {
+                                return true;
+                            }
+                        }
+                    }
+
+                    value = pso.BaseObject;
+                    if (value == null) { return false; }
+                }
+
+                var valueType = value.GetType();
+                return valueType != null
+                    && string.Equals(valueType.Namespace, "AtlassianPS.JiraAgilePS", StringComparison.Ordinal);
+            }
+
+            public static object TransformOrFanout(object inputData, Func<object, object> perItem)
+            {
+                if (inputData == null) { return null; }
+
+                var pso = inputData as PSObject;
+                object value = pso != null ? pso.BaseObject : inputData;
+
+                if (value is string) { return perItem(inputData); }
+                if (value is IDictionary) { return perItem(inputData); }
+
+                var enumerable = value as IEnumerable;
+                if (enumerable != null)
+                {
+                    var results = new List<object>();
+                    foreach (var item in enumerable)
+                    {
+                        results.Add(perItem(item));
+                    }
+                    return results.ToArray();
+                }
+
+                return perItem(inputData);
+            }
+
+            public static Uri ToUri(object value)
+            {
+                if (value == null) { return null; }
+
+                var uri = value as Uri;
+                if (uri != null) { return uri; }
+
+                var text = value.ToString();
+                if (string.IsNullOrWhiteSpace(text)) { return null; }
+
+                return new Uri(text, UriKind.RelativeOrAbsolute);
+            }
+
+            public static bool HasAnyProperty(PSObject pso, params string[] propertyNames)
+            {
+                if (pso == null || pso.Properties == null) { return false; }
+                foreach (var propertyName in propertyNames)
+                {
+                    if (pso.Properties[propertyName] != null) { return true; }
+                }
+                return false;
+            }
+        }
+
+        public abstract class JiraAgileTransformationAttribute : ArgumentTransformationAttribute
+        {
+            protected abstract Type TargetType { get; }
+            protected abstract object FromString(string value);
+
+            protected virtual object FromNumericScalar(UInt64 value) { return null; }
+            protected virtual bool ShouldMapLegacyObject(PSObject pso) { return false; }
+            protected virtual object MapLegacyObject(PSObject pso) { return null; }
+
+            public sealed override object Transform(EngineIntrinsics engineIntrinsics, object inputData)
+            {
+                return JiraAgileTransform.TransformOrFanout(inputData, TransformOne);
+            }
+
+            private object TransformOne(object inputData)
+            {
+                if (inputData == null) { return null; }
+
+                var pso = inputData as PSObject;
+                object value = pso != null ? pso.BaseObject : inputData;
+
+                var targetType = TargetType;
+                if (targetType.IsInstanceOfType(value)) { return value; }
+
+                // Preserve binder fallthrough for competing ValueFromPipeline
+                // parameter sets when the piped value is another JiraAgilePS
+                // domain type.
+                if (JiraAgileTransform.IsJiraAgileDomainObject(inputData))
+                {
+                    return inputData;
+                }
+
+                UInt64 numericValue;
+                if (JiraAgileTransform.TryConvertToUInt64(value, out numericValue))
+                {
+                    var numeric = FromNumericScalar(numericValue);
+                    if (numeric != null) { return numeric; }
+                }
+
+                var text = value as string;
+                if (text != null)
+                {
+                    if (string.IsNullOrWhiteSpace(text))
+                    {
+                        throw new ArgumentTransformationMetadataException(
+                            "Cannot bind an empty or whitespace string to a " + targetType.FullName + " parameter.");
+                    }
+
+                    return FromString(text);
+                }
+
+                if (ShouldMapLegacyObject(pso))
+                {
+                    var mapped = MapLegacyObject(pso);
+                    if (mapped != null) { return mapped; }
+                }
+                return inputData;
+            }
+        }
+
+        [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Parameter, AllowMultiple = false)]
+        public sealed class BoardTransformationAttribute : JiraAgileTransformationAttribute
+        {
+            protected override Type TargetType { get { return typeof(Board); } }
+            protected override object FromString(string value) { return new Board(value); }
+            protected override object FromNumericScalar(UInt64 value) { return new Board(value); }
+
+            protected override bool ShouldMapLegacyObject(PSObject pso)
+            {
+                return JiraAgileTransform.HasAnyProperty(pso, "Id", "id", "Name", "name", "Type", "type", "Self", "self");
+            }
+
+            protected override object MapLegacyObject(PSObject pso)
+            {
+                var board = new Board();
+                foreach (var prop in pso.Properties)
+                {
+                    switch (prop.Name)
+                    {
+                        case "Id":
+                        case "id":
+                        case "ID":
+                            UInt64 id;
+                            if (JiraAgileTransform.TryConvertToUInt64(prop.Value, out id))
+                            {
+                                board.Id = id;
+                            }
+                            break;
+                        case "Name":
+                        case "name":
+                            board.Name = prop.Value as string ?? (prop.Value != null ? prop.Value.ToString() : null);
+                            break;
+                        case "Type":
+                        case "type":
+                            if (prop.Value != null)
+                            {
+                                BoardType boardType;
+                                if (Enum.TryParse<BoardType>(prop.Value.ToString(), true, out boardType))
+                                {
+                                    board.Type = boardType;
+                                }
+                            }
+                            break;
+                        case "Self":
+                        case "self":
+                            board.Self = JiraAgileTransform.ToUri(prop.Value);
+                            break;
+                    }
+                }
+
+                return board;
+            }
+        }
+
+        [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Parameter, AllowMultiple = false)]
+        public sealed class SprintTransformationAttribute : JiraAgileTransformationAttribute
+        {
+            protected override Type TargetType { get { return typeof(Sprint); } }
+            protected override object FromString(string value) { return new Sprint(value); }
+            protected override object FromNumericScalar(UInt64 value) { return new Sprint(value); }
+
+            protected override bool ShouldMapLegacyObject(PSObject pso)
+            {
+                return JiraAgileTransform.HasAnyProperty(pso, "Id", "id", "Name", "name", "State", "state", "Self", "self");
+            }
+
+            protected override object MapLegacyObject(PSObject pso)
+            {
+                var sprint = new Sprint();
+                foreach (var prop in pso.Properties)
+                {
+                    switch (prop.Name)
+                    {
+                        case "Id":
+                        case "id":
+                        case "ID":
+                            UInt64 id;
+                            if (JiraAgileTransform.TryConvertToUInt64(prop.Value, out id))
+                            {
+                                sprint.Id = id;
+                            }
+                            break;
+                        case "Name":
+                        case "name":
+                            sprint.Name = prop.Value as string ?? (prop.Value != null ? prop.Value.ToString() : null);
+                            break;
+                        case "State":
+                        case "state":
+                            if (prop.Value != null)
+                            {
+                                SprintState sprintState;
+                                if (Enum.TryParse<SprintState>(prop.Value.ToString(), true, out sprintState))
+                                {
+                                    sprint.State = sprintState;
+                                }
+                            }
+                            break;
+                        case "StartDate":
+                        case "startDate":
+                            DateTime startDate;
+                            if (prop.Value != null && DateTime.TryParse(prop.Value.ToString(), out startDate))
+                            {
+                                sprint.StartDate = startDate;
+                            }
+                            break;
+                        case "EndDate":
+                        case "endDate":
+                            DateTime endDate;
+                            if (prop.Value != null && DateTime.TryParse(prop.Value.ToString(), out endDate))
+                            {
+                                sprint.EndDate = endDate;
+                            }
+                            break;
+                        case "CompleteDate":
+                        case "completeDate":
+                            DateTime completeDate;
+                            if (prop.Value != null && DateTime.TryParse(prop.Value.ToString(), out completeDate))
+                            {
+                                sprint.CompleteDate = completeDate;
+                            }
+                            break;
+                        case "OriginBoardId":
+                        case "originBoardId":
+                            UInt64 originBoardId;
+                            if (JiraAgileTransform.TryConvertToUInt64(prop.Value, out originBoardId))
+                            {
+                                sprint.OriginBoardId = originBoardId;
+                            }
+                            break;
+                        case "Goal":
+                        case "goal":
+                            sprint.Goal = prop.Value as string ?? (prop.Value != null ? prop.Value.ToString() : null);
+                            break;
+                        case "Self":
+                        case "self":
+                            sprint.Self = JiraAgileTransform.ToUri(prop.Value);
+                            break;
+                    }
+                }
+
+                return sprint;
+            }
+        }
+
+        [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Parameter, AllowMultiple = false)]
+        public sealed class EpicTransformationAttribute : JiraAgileTransformationAttribute
+        {
+            protected override Type TargetType { get { return typeof(Epic); } }
+            protected override object FromString(string value) { return new Epic(value); }
+            protected override object FromNumericScalar(UInt64 value) { return new Epic(value); }
+
+            protected override bool ShouldMapLegacyObject(PSObject pso)
+            {
+                return JiraAgileTransform.HasAnyProperty(pso, "Id", "id", "Key", "key", "Name", "name", "Self", "self");
+            }
+
+            protected override object MapLegacyObject(PSObject pso)
+            {
+                var epic = new Epic();
+                foreach (var prop in pso.Properties)
+                {
+                    switch (prop.Name)
+                    {
+                        case "Id":
+                        case "id":
+                        case "ID":
+                            UInt64 id;
+                            if (JiraAgileTransform.TryConvertToUInt64(prop.Value, out id))
+                            {
+                                epic.Id = id;
+                            }
+                            break;
+                        case "Key":
+                        case "key":
+                            epic.Key = prop.Value as string ?? (prop.Value != null ? prop.Value.ToString() : null);
+                            break;
+                        case "Name":
+                        case "name":
+                            epic.Name = prop.Value as string ?? (prop.Value != null ? prop.Value.ToString() : null);
+                            break;
+                        case "Summary":
+                        case "summary":
+                            epic.Summary = prop.Value as string ?? (prop.Value != null ? prop.Value.ToString() : null);
+                            break;
+                        case "Color":
+                        case "color":
+                            epic.Color = prop.Value as string ?? (prop.Value != null ? prop.Value.ToString() : null);
+                            break;
+                        case "Done":
+                        case "done":
+                            bool done;
+                            if (prop.Value != null && bool.TryParse(prop.Value.ToString(), out done))
+                            {
+                                epic.Done = done;
+                            }
+                            break;
+                        case "Self":
+                        case "self":
+                            epic.Self = JiraAgileTransform.ToUri(prop.Value);
+                            break;
+                    }
+                }
+
+                return epic;
+            }
+        }
+
         public class Board
         {
             public Board(UInt64 value) { Id = value; }

--- a/JiraAgilePS/Public/Add-IssueToSprint.ps1
+++ b/JiraAgilePS/Public/Add-IssueToSprint.ps1
@@ -8,6 +8,7 @@ function Add-IssueToSprint {
         $Issue,
 
         [Parameter( Mandatory )]
+        [AtlassianPS.JiraAgilePS.SprintTransformation()]
         [AtlassianPS.JiraAgilePS.Sprint]
         $Sprint,
 

--- a/JiraAgilePS/Public/Get-BoardConfiguration.ps1
+++ b/JiraAgilePS/Public/Get-BoardConfiguration.ps1
@@ -4,6 +4,7 @@ function Get-BoardConfiguration {
     [OutputType([PSObject])]
     param(
         [Parameter(Position = 0, Mandatory, ValueFromPipeline)]
+        [AtlassianPS.JiraAgilePS.BoardTransformation()]
         [AtlassianPS.JiraAgilePS.Board]
         $Board,
 

--- a/JiraAgilePS/Public/Get-Epic.ps1
+++ b/JiraAgilePS/Public/Get-Epic.ps1
@@ -4,10 +4,12 @@ function Get-Epic {
     [OutputType([AtlassianPS.JiraAgilePS.Epic])]
     param(
         [Parameter(Position = 0, Mandatory, ValueFromPipeline, ParameterSetName = '_ById')]
+        [AtlassianPS.JiraAgilePS.EpicTransformation()]
         [AtlassianPS.JiraAgilePS.Epic[]]
         $Epic,
 
         [Parameter(Position = 0, Mandatory, ValueFromPipeline, ParameterSetName = '_ByBoard')]
+        [AtlassianPS.JiraAgilePS.BoardTransformation()]
         [AtlassianPS.JiraAgilePS.Board]
         $Board,
 

--- a/JiraAgilePS/Public/Get-Issue.ps1
+++ b/JiraAgilePS/Public/Get-Issue.ps1
@@ -8,6 +8,7 @@ function Get-Issue {
         [Parameter(Position = 0, Mandatory, ValueFromPipeline, ParameterSetName = '_Sprint')]
         [Parameter(Position = 0, Mandatory, ValueFromPipeline, ParameterSetName = '_BoardEpic')]
         [Parameter(Position = 0, Mandatory, ValueFromPipeline, ParameterSetName = '_BoardWithoutEpic')]
+        [AtlassianPS.JiraAgilePS.BoardTransformation()]
         [AtlassianPS.JiraAgilePS.Board]
         $Board,
 
@@ -16,11 +17,13 @@ function Get-Issue {
         $Backlog,
 
         [Parameter(Position = 1, Mandatory, ValueFromPipeline, ParameterSetName = '_Sprint')]
+        [AtlassianPS.JiraAgilePS.SprintTransformation()]
         [AtlassianPS.JiraAgilePS.Sprint[]]
         $Sprint,
 
         [Parameter(Position = 0, Mandatory, ValueFromPipeline, ParameterSetName = '_Epic')]
         [Parameter(Position = 1, Mandatory, ValueFromPipeline, ParameterSetName = '_BoardEpic')]
+        [AtlassianPS.JiraAgilePS.EpicTransformation()]
         [AtlassianPS.JiraAgilePS.Epic[]]
         $Epic,
 

--- a/JiraAgilePS/Public/Get-Sprint.ps1
+++ b/JiraAgilePS/Public/Get-Sprint.ps1
@@ -4,11 +4,13 @@ function Get-Sprint {
     [OutputType( [AtlassianPS.JiraAgilePS.Sprint] )]
     param(
         [Parameter( Position = 0, Mandatory, ValueFromPipeline, ParameterSetName = '_ById' )]
+        [AtlassianPS.JiraAgilePS.SprintTransformation()]
         [AtlassianPS.JiraAgilePS.Sprint[]]
         $Sprint,
 
 
         [Parameter( Position, Mandatory, ValueFromPipeline, ParameterSetName = '_All' )]
+        [AtlassianPS.JiraAgilePS.BoardTransformation()]
         [AtlassianPS.JiraAgilePS.Board]
         $Board,
 

--- a/Tests/Functions/Public/Add-IssueToSprint.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Add-IssueToSprint.Unit.Tests.ps1
@@ -90,6 +90,18 @@ InModuleScope JiraAgilePS {
                 Should -Invoke -CommandName Invoke-JiraMethod -ModuleName JiraAgilePS -Exactly -Times 1 -Scope It
             }
 
+            It "accepts numeric sprint ids via transformer and resolves sprint details" {
+                $issues = @([pscustomobject]@{ Key = "AG-1" })
+
+                { Add-JiraAgileIssueToSprint -Issue $issues -Sprint 99 } | Should -Not -Throw
+
+                Should -Invoke -CommandName Get-Sprint -ModuleName JiraAgilePS -Exactly -Times 1 -Scope It
+                Should -Invoke -CommandName Invoke-JiraMethod -ModuleName JiraAgilePS -Exactly -Times 1 -Scope It -ParameterFilter {
+                    $Method -eq "POST" -and
+                    $Uri -eq "$sprintUri/issue"
+                }
+            }
+
             It "sends sprint issue payloads in pages of 50 issue keys" {
                 $sprint = [AtlassianPS.JiraAgilePS.Sprint]::new(99)
                 $sprint.Self = [Uri]$sprintUri

--- a/Tests/Functions/Public/Get-BoardConfiguration.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Get-BoardConfiguration.Unit.Tests.ps1
@@ -58,6 +58,27 @@ InModuleScope JiraAgilePS {
                 $result.filter.id | Should -Be 10030
                 $result.PSObject.TypeNames[0] | Should -Be "AtlassianPS.JiraAgilePS.BoardConfiguration"
             }
+
+            It "accepts numeric board ids via transformer" {
+                Mock Invoke-JiraMethod -ModuleName JiraAgilePS {
+                    [pscustomobject]@{
+                        id     = 9
+                        name   = "Main board"
+                        type   = "scrum"
+                        filter = [pscustomobject]@{
+                            id   = 10030
+                            self = "$jiraServer/rest/api/2/filter/10030"
+                        }
+                    }
+                }
+
+                $null = Get-JiraAgileBoardConfiguration -Board 9
+
+                Should -Invoke -CommandName Invoke-JiraMethod -ModuleName JiraAgilePS -Exactly -Times 1 -Scope It -ParameterFilter {
+                    $Method -eq "GET" -and
+                    $Uri -eq "$jiraServer/rest/agile/1.0/board/9/configuration"
+                }
+            }
         }
     }
 }

--- a/Tests/Functions/Public/Get-Epic.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Get-Epic.Unit.Tests.ps1
@@ -69,6 +69,24 @@ InModuleScope JiraAgilePS {
                 (@($result | Select-Object -ExpandProperty Key) -join ",") | Should -Be "EPIC-41,EPIC-42"
             }
 
+            It "accepts numeric epic ids via transformer" {
+                Mock Invoke-JiraMethod -ModuleName JiraAgilePS {
+                    [pscustomobject]@{
+                        id   = 41
+                        key  = "EPIC-41"
+                        name = "Epic 41"
+                        self = "$jiraServer/rest/agile/1.0/epic/41"
+                    }
+                }
+
+                $null = Get-JiraAgileEpic -Epic 41
+
+                Should -Invoke -CommandName Invoke-JiraMethod -ModuleName JiraAgilePS -Exactly -Times 1 -Scope It -ParameterFilter {
+                    $Method -eq "GET" -and
+                    $Uri -eq "$jiraServer/rest/agile/1.0/epic/41"
+                }
+            }
+
             It "requests board epics when Board is supplied" {
                 Mock Invoke-JiraMethod -ModuleName JiraAgilePS {
                     [pscustomobject]@{
@@ -104,6 +122,22 @@ InModuleScope JiraAgilePS {
                 $result[0] | Should -BeOfType [AtlassianPS.JiraAgilePS.Epic]
                 $result[0].Name | Should -Be "Epic 31"
                 $result[1].Done | Should -BeTrue
+            }
+
+            It "accepts numeric board ids via transformer" {
+                Mock Invoke-JiraMethod -ModuleName JiraAgilePS {
+                    [pscustomobject]@{
+                        values = @()
+                    }
+                }
+
+                $null = Get-JiraAgileEpic -Board 5
+
+                Should -Invoke -CommandName Invoke-JiraMethod -ModuleName JiraAgilePS -Exactly -Times 1 -Scope It -ParameterFilter {
+                    $Method -eq "GET" -and
+                    $Uri -eq "$jiraServer/rest/agile/1.0/board/5/epic" -and
+                    $Paging
+                }
             }
 
             It "accepts Board from pipeline in board parameter set" {

--- a/Tests/Functions/Public/Get-Issue.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Get-Issue.Unit.Tests.ps1
@@ -66,6 +66,16 @@ InModuleScope JiraAgilePS {
                 $result[0].Key | Should -Be "AG-1000"
             }
 
+            It "accepts numeric board ids via transformer" {
+                $null = Get-JiraAgileIssue -Board 7
+
+                Should -Invoke -CommandName Invoke-JiraMethod -ModuleName JiraAgilePS -Exactly -Times 1 -Scope It -ParameterFilter {
+                    $Method -eq "GET" -and
+                    $Uri -eq "$jiraServer/rest/agile/1.0/board/7/issue" -and
+                    $Paging
+                }
+            }
+
             It "uses backlog endpoint when Backlog switch is specified" {
                 $board = [AtlassianPS.JiraAgilePS.Board]::new(8)
 
@@ -100,6 +110,16 @@ InModuleScope JiraAgilePS {
                 @($result).Count | Should -Be 2
             }
 
+            It "accepts numeric sprint ids via transformer" {
+                $null = Get-JiraAgileIssue -Board 9 -Sprint 21
+
+                Should -Invoke -CommandName Invoke-JiraMethod -ModuleName JiraAgilePS -Exactly -Times 1 -Scope It -ParameterFilter {
+                    $Method -eq "GET" -and
+                    $Uri -eq "$jiraServer/rest/agile/1.0/board/9/sprint/21/issue" -and
+                    $Paging
+                }
+            }
+
             It "uses epic endpoint when Epic is supplied without Board" {
                 $epicA = [AtlassianPS.JiraAgilePS.Epic]::new(55)
                 $epicB = [AtlassianPS.JiraAgilePS.Epic]::new(56)
@@ -118,6 +138,16 @@ InModuleScope JiraAgilePS {
                     $Paging
                 }
                 @($result).Count | Should -Be 2
+            }
+
+            It "accepts numeric epic ids via transformer" {
+                $null = Get-JiraAgileIssue -Epic 55
+
+                Should -Invoke -CommandName Invoke-JiraMethod -ModuleName JiraAgilePS -Exactly -Times 1 -Scope It -ParameterFilter {
+                    $Method -eq "GET" -and
+                    $Uri -eq "$jiraServer/rest/agile/1.0/epic/55/issue" -and
+                    $Paging
+                }
             }
 
             It "uses board epic endpoint when Board and Epic are supplied" {

--- a/Tests/Functions/Public/Get-Sprint.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Get-Sprint.Unit.Tests.ps1
@@ -71,6 +71,25 @@ InModuleScope JiraAgilePS {
                 $result.Name | Should -Be "Sprint 13"
             }
 
+            It "accepts numeric board ids via transformer" {
+                Mock Invoke-JiraMethod -ModuleName JiraAgilePS {
+                    [pscustomobject]@{
+                        Id    = 13
+                        Name  = "Sprint 13"
+                        State = "active"
+                        Self  = "$jiraServer/rest/agile/1.0/sprint/13"
+                    }
+                }
+
+                $null = Get-JiraAgileSprint -Board 4
+
+                Should -Invoke -CommandName Invoke-JiraMethod -ModuleName JiraAgilePS -Exactly -Times 1 -Scope It -ParameterFilter {
+                    $Method -eq "GET" -and
+                    $Uri -eq "$jiraServer/rest/agile/1.0/board/4/sprint" -and
+                    $Paging
+                }
+            }
+
             It "requests sprint details by sprint id" {
                 Mock Invoke-JiraMethod -ModuleName JiraAgilePS {
                     [pscustomobject]@{
@@ -96,6 +115,25 @@ InModuleScope JiraAgilePS {
                 }
                 $result.Id | Should -Be 21
                 $result.Name | Should -Be "Sprint 21"
+            }
+
+            It "accepts numeric sprint ids via transformer" {
+                Mock Invoke-JiraMethod -ModuleName JiraAgilePS {
+                    [pscustomobject]@{
+                        Id    = 21
+                        Name  = "Sprint 21"
+                        State = "future"
+                        Self  = "$jiraServer/rest/agile/1.0/sprint/21"
+                    }
+                }
+
+                $null = Get-JiraAgileSprint -Sprint 21
+
+                Should -Invoke -CommandName Invoke-JiraMethod -ModuleName JiraAgilePS -Exactly -Times 1 -Scope It -ParameterFilter {
+                    $Method -eq "GET" -and
+                    $Uri -eq "$jiraServer/rest/agile/1.0/sprint/21" -and
+                    (-not $Paging)
+                }
             }
 
             It "requests each sprint id independently when multiple sprints are supplied" {


### PR DESCRIPTION
## Summary
- add JiraPS-inspired argument transformation attributes for JiraAgilePS Board, Sprint, and Epic types
- apply those transformers on typed cmdlet parameters so callers can pass numeric identifiers directly
- extend unit coverage across affected cmdlets to verify transformed binding paths

## Details
- introduces JiraAgileTransformationAttribute base behavior in JiraAgilePS.Types.cs
- adds BoardTransformationAttribute, SprintTransformationAttribute, and EpicTransformationAttribute
- wires transformer attributes in:
  - Get-JiraAgileIssue
  - Get-JiraAgileEpic
  - Get-JiraAgileSprint
  - Get-JiraAgileBoardConfiguration
  - Add-JiraAgileIssueToSprint
- updates changelog with the new binding behavior

## Validation
- Invoke-Pester -Path 'Tests'
- Invoke-Build -Task Build, Test

Closes #25