### PR TITLE
Align JiraAgile release publish and versioning with JiraPS

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,7 @@ jobs:
           path: ./Release/
           if_no_artifact_found: fail
 
-      - uses: AtlassianPS/AtlassianPS.Standards/.github/actions/setup-powershell@v0.1.6
+      - uses: AtlassianPS/AtlassianPS.Standards/.github/actions/setup-powershell@9a9367e22847bd24f86208ed2d98d207b0e2a3b3 # v0.1.6
 
       - name: Publish module
         run: Invoke-Build -Task Publish -VersionToPublish ${{ steps.release_ref.outputs.release_tag }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,17 +50,10 @@ jobs:
 
       - uses: AtlassianPS/AtlassianPS.Standards/.github/actions/setup-powershell@v0.1.6
 
-      - name: Publish to PowerShell Gallery
+      - name: Publish module
+        run: Invoke-Build -Task Publish -VersionToPublish ${{ steps.release_ref.outputs.release_tag }}
+          -PSGalleryAPIKey ${{ secrets.PSGALLERY_API_KEY }}
         shell: pwsh
-        run: |
-          Import-Module AtlassianPS.Standards -RequiredVersion 0.1.2 -ErrorAction Stop
-          Publish-AtlassianPSModuleRelease -BuildOutputPath ./Release -ModuleName JiraAgilePS -ApiKey ${{ secrets.PSGALLERY_API_KEY }}
-
-      - name: Package release zip
-        shell: pwsh
-        run: |
-          Import-Module AtlassianPS.Standards -RequiredVersion 0.1.2 -ErrorAction Stop
-          $null = New-AtlassianPSModulePackage -BuildOutputPath ./Release -ModuleName JiraAgilePS
 
       - name: Create Release and Upload Asset
         uses: softprops/action-gh-release@v3

--- a/JiraAgilePS.build.ps1
+++ b/JiraAgilePS.build.ps1
@@ -225,11 +225,8 @@ task UpdateManifest GetNextVersion, {
 }
 
 # Synopsis: Create a ZIP file with this build
-task Package Init, {
-    Assert-True { Test-Path "$env:BHBuildOutput\$env:BHProjectName" } "Missing files to package"
-
-    Remove-Item "$env:BHBuildOutput\$env:BHProjectName.zip" -ErrorAction SilentlyContinue
-    $null = Compress-Archive -Path "$env:BHBuildOutput\$env:BHProjectName" -DestinationPath "$env:BHBuildOutput\$env:BHProjectName.zip"
+task Package Init, EnsureReleaseStandardsModule, {
+    $null = New-AtlassianPSModulePackage -BuildOutputPath $env:BHBuildOutput -ModuleName $env:BHProjectName
 }
 #endregion BuildRelease
 
@@ -332,12 +329,16 @@ task SetVersion {
     }
 }
 
+task EnsureReleaseStandardsModule {
+    Import-Module AtlassianPS.Standards -RequiredVersion 0.1.6 -ErrorAction Stop
+}
+
 # Synopsis: Publish prepared release artifacts to PSGallery and package zip.
-task Publish Init, SetVersion, Package, {
+task Publish Init, EnsureReleaseStandardsModule, SetVersion, Package, {
     Assert-True (-not [String]::IsNullOrEmpty($PSGalleryAPIKey)) "No key for the PSGallery"
     Assert-True { Test-Path "$env:BHBuildOutput/$env:BHProjectName" } "Missing files to publish"
 
-    Publish-Module -Path "$env:BHBuildOutput/$env:BHProjectName" -NuGetApiKey $PSGalleryAPIKey
+    Publish-AtlassianPSModuleRelease -BuildOutputPath $env:BHBuildOutput -ModuleName $env:BHProjectName -ApiKey $PSGalleryAPIKey
 }
 
 # Synpsis: Publish the $release to the PSGallery

--- a/JiraAgilePS.build.ps1
+++ b/JiraAgilePS.build.ps1
@@ -6,6 +6,7 @@
 param(
     [String[]]$Tag,
     [String[]]$ExcludeTag = @("Integration"),
+    [String]$VersionToPublish,
     [String]$PSGalleryAPIKey,
     [String]$GithubAccessToken
 )
@@ -16,6 +17,9 @@ if ($PSBoundParameters.ContainsKey('Verbose')) {
 }
 if ($PSBoundParameters.ContainsKey('Debug')) {
     $DebugPreference = "Continue"
+}
+if ($VersionToPublish) {
+    $VersionToPublish = $VersionToPublish.TrimStart('v')
 }
 
 try {
@@ -293,6 +297,48 @@ task Test Init, {
 #region Publish
 # Synopsis: Publish a new release on github and the PSGallery
 task Deploy Init, PublishToGallery, TagReplository, UpdateHomepage
+
+# Synopsis: Set the module manifest version from the release tag.
+task SetVersion {
+    Assert-True (-not [String]::IsNullOrWhiteSpace($VersionToPublish)) "VersionToPublish is required for Publish."
+    [System.Management.Automation.SemanticVersion]$versionToPublish = $VersionToPublish
+
+    $published = Find-Module -Name $env:BHProjectName -ErrorAction SilentlyContinue
+    if ($published) {
+        [System.Management.Automation.SemanticVersion]$latestPublished = $published.Version
+        Write-Build Gray "Latest published version: $latestPublished"
+        Assert-True { $versionToPublish -gt $latestPublished } "Version must be greater than latest published version: $latestPublished"
+    }
+    else {
+        Write-Build Gray "No published version found in PSGallery; skipping version guard"
+    }
+
+    $manifestPath = "$env:BHBuildOutput/$env:BHProjectName/$env:BHProjectName.psd1"
+    Assert-True (Test-Path $manifestPath) "Built module manifest was not found: $manifestPath"
+
+    $versionString = "{0}.{1}.{2}" -f $versionToPublish.Major, $versionToPublish.Minor, $versionToPublish.Patch
+    if ($versionToPublish.PreReleaseLabel) {
+        Write-Build Gray "Setting Prerelease label: $($versionToPublish.PreReleaseLabel)"
+        Update-ModuleManifest -Path $manifestPath -ModuleVersion $versionString -Prerelease $versionToPublish.PreReleaseLabel
+    }
+    else {
+        Write-Build Gray "Removing Prerelease label (stable release)"
+        Update-ModuleManifest -Path $manifestPath -ModuleVersion $versionString
+
+        $manifestContent = Get-Content -Path $manifestPath -Raw
+        $manifestContent = $manifestContent -replace "(?m)^\s*Prerelease\s*=\s*'[^']*'\r?\n", ""
+        Set-Content -Path $manifestPath -Value $manifestContent -Encoding UTF8 -Force
+        Remove-Utf8Bom -Path $manifestPath
+    }
+}
+
+# Synopsis: Publish prepared release artifacts to PSGallery and package zip.
+task Publish Init, SetVersion, Package, {
+    Assert-True (-not [String]::IsNullOrEmpty($PSGalleryAPIKey)) "No key for the PSGallery"
+    Assert-True { Test-Path "$env:BHBuildOutput/$env:BHProjectName" } "Missing files to publish"
+
+    Publish-Module -Path "$env:BHBuildOutput/$env:BHProjectName" -NuGetApiKey $PSGalleryAPIKey
+}
 
 # Synpsis: Publish the $release to the PSGallery
 task PublishToGallery {

--- a/JiraAgilePS.build.ps1
+++ b/JiraAgilePS.build.ps1
@@ -225,7 +225,8 @@ task UpdateManifest GetNextVersion, {
 }
 
 # Synopsis: Create a ZIP file with this build
-task Package Init, EnsureReleaseStandardsModule, {
+task Package Init, {
+    Import-Module AtlassianPS.Standards -RequiredVersion 0.1.6 -ErrorAction Stop
     $null = New-AtlassianPSModulePackage -BuildOutputPath $env:BHBuildOutput -ModuleName $env:BHProjectName
 }
 #endregion BuildRelease
@@ -329,15 +330,12 @@ task SetVersion {
     }
 }
 
-task EnsureReleaseStandardsModule {
-    Import-Module AtlassianPS.Standards -RequiredVersion 0.1.6 -ErrorAction Stop
-}
-
 # Synopsis: Publish prepared release artifacts to PSGallery and package zip.
-task Publish Init, EnsureReleaseStandardsModule, SetVersion, Package, {
+task Publish Init, SetVersion, Package, {
     Assert-True (-not [String]::IsNullOrEmpty($PSGalleryAPIKey)) "No key for the PSGallery"
     Assert-True { Test-Path "$env:BHBuildOutput/$env:BHProjectName" } "Missing files to publish"
 
+    Import-Module AtlassianPS.Standards -RequiredVersion 0.1.6 -ErrorAction Stop
     Publish-AtlassianPSModuleRelease -BuildOutputPath $env:BHBuildOutput -ModuleName $env:BHProjectName -ApiKey $PSGalleryAPIKey
 }
 


### PR DESCRIPTION
## Summary
- replace direct standards release function calls in .github/workflows/release.yml with Invoke-Build Task Publish
- pass VersionToPublish from resolved release tag in workflow
- add VersionToPublish parameter and SetVersion task in JiraAgilePS.build.ps1
- make Publish depend on SetVersion and Package
- enforce version monotonicity against PSGallery when available and set prerelease metadata from tag

## Why
JiraPS is the golden reference and enforces tag-aligned manifest versioning before publish.

## Validation
- Invoke-Build -Task Build, Test
- Invoke-Build -Task Build, SetVersion -VersionToPublish v9999.0.0-alpha1