### PR TITLE
Add JiraAgilePS private test coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 ### Changed
 
 - Harmonized integration test environment setup with JiraPS by adopting `.env.example` and a shared-style `.env` loader/validator in `Tests/Helpers/IntegrationTestTools.ps1`.
+- Added JiraPS-style test guidance and private helper/converter unit coverage for JiraAgilePS.
 
 ### Fixed
 

--- a/Tests/Functions/Private/ConvertTo-Board.Unit.Tests.ps1
+++ b/Tests/Functions/Private/ConvertTo-Board.Unit.Tests.ps1
@@ -1,0 +1,45 @@
+#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+
+BeforeDiscovery {
+    . "$PSScriptRoot/../../Helpers/TestTools.ps1"
+
+    $script:moduleToTest = Initialize-TestEnvironment
+}
+
+InModuleScope JiraAgilePS {
+    Describe "ConvertTo-Board" -Tag 'Unit' {
+        BeforeAll {
+            . "$PSScriptRoot/../../Helpers/TestTools.ps1"
+
+            $script:boardPayload = [pscustomobject]@{
+                id   = 7
+                name = 'Delivery board'
+                type = 'scrum'
+                self = 'https://jira.example.com/rest/agile/1.0/board/7'
+            }
+        }
+
+        Describe "Behavior" {
+            BeforeAll {
+                $script:result = ConvertTo-Board -InputObject $boardPayload
+            }
+
+            It "returns a typed board object" {
+                $result | Should -BeOfType ([AtlassianPS.JiraAgilePS.Board])
+            }
+
+            It "maps board properties" {
+                $result.Id | Should -Be 7
+                $result.Name | Should -Be 'Delivery board'
+                $result.Type | Should -Be ([AtlassianPS.JiraAgilePS.BoardType]::scrum)
+                $result.Self.AbsoluteUri | Should -Be 'https://jira.example.com/rest/agile/1.0/board/7'
+            }
+
+            It "accepts pipeline input" {
+                $pipelineResult = $boardPayload | ConvertTo-Board
+
+                $pipelineResult.Id | Should -Be 7
+            }
+        }
+    }
+}

--- a/Tests/Functions/Private/ConvertTo-BoardConfiguration.Unit.Tests.ps1
+++ b/Tests/Functions/Private/ConvertTo-BoardConfiguration.Unit.Tests.ps1
@@ -1,0 +1,45 @@
+#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+
+BeforeDiscovery {
+    . "$PSScriptRoot/../../Helpers/TestTools.ps1"
+
+    $script:moduleToTest = Initialize-TestEnvironment
+}
+
+InModuleScope JiraAgilePS {
+    Describe "ConvertTo-BoardConfiguration" -Tag 'Unit' {
+        BeforeAll {
+            . "$PSScriptRoot/../../Helpers/TestTools.ps1"
+
+            $script:configurationPayload = [pscustomobject]@{
+                id       = 42
+                name     = 'Delivery configuration'
+                location = [pscustomobject]@{
+                    projectKey = 'DEL'
+                }
+            }
+        }
+
+        Describe "Behavior" {
+            It "adds the board configuration type name" {
+                $result = ConvertTo-BoardConfiguration -InputObject $configurationPayload
+
+                $result.PSObject.TypeNames[0] | Should -Be 'AtlassianPS.JiraAgilePS.BoardConfiguration'
+            }
+
+            It "preserves payload properties" {
+                $result = ConvertTo-BoardConfiguration -InputObject $configurationPayload
+
+                $result.id | Should -Be 42
+                $result.name | Should -Be 'Delivery configuration'
+                $result.location.projectKey | Should -Be 'DEL'
+            }
+
+            It "ignores null pipeline input" {
+                $result = $null | ConvertTo-BoardConfiguration
+
+                $result | Should -BeNullOrEmpty
+            }
+        }
+    }
+}

--- a/Tests/Functions/Private/ConvertTo-Epic.Unit.Tests.ps1
+++ b/Tests/Functions/Private/ConvertTo-Epic.Unit.Tests.ps1
@@ -1,0 +1,57 @@
+#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+
+BeforeDiscovery {
+    . "$PSScriptRoot/../../Helpers/TestTools.ps1"
+
+    $script:moduleToTest = Initialize-TestEnvironment
+}
+
+InModuleScope JiraAgilePS {
+    Describe "ConvertTo-Epic" -Tag 'Unit' {
+        BeforeAll {
+            . "$PSScriptRoot/../../Helpers/TestTools.ps1"
+
+            $script:epicPayload = [pscustomobject]@{
+                id      = 10001
+                key     = 'DEL-1'
+                name    = 'Launch epic'
+                summary = 'Launch the product'
+                color   = [pscustomobject]@{ key = 'color_1' }
+                done    = $true
+                self    = 'https://jira.example.com/rest/agile/1.0/epic/10001'
+            }
+        }
+
+        Describe "Behavior" {
+            BeforeAll {
+                $script:result = ConvertTo-Epic -InputObject $epicPayload
+            }
+
+            It "returns a typed epic object" {
+                $result | Should -BeOfType ([AtlassianPS.JiraAgilePS.Epic])
+            }
+
+            It "maps epic properties" {
+                $result.Id | Should -Be 10001
+                $result.Key | Should -Be 'DEL-1'
+                $result.Name | Should -Be 'Launch epic'
+                $result.Summary | Should -Be 'Launch the product'
+                $result.Color | Should -Be 'color_1'
+                $result.Done | Should -BeTrue
+                $result.Self.AbsoluteUri | Should -Be 'https://jira.example.com/rest/agile/1.0/epic/10001'
+            }
+
+            It "normalizes color object name when key is absent" {
+                $payload = [pscustomobject]@{ id = 2; color = [pscustomobject]@{ name = 'green' } }
+
+                (ConvertTo-Epic -InputObject $payload).Color | Should -Be 'green'
+            }
+
+            It "accepts pipeline input" {
+                $pipelineResult = $epicPayload | ConvertTo-Epic
+
+                $pipelineResult.Key | Should -Be 'DEL-1'
+            }
+        }
+    }
+}

--- a/Tests/Functions/Private/ConvertTo-Issue.Unit.Tests.ps1
+++ b/Tests/Functions/Private/ConvertTo-Issue.Unit.Tests.ps1
@@ -1,0 +1,45 @@
+#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+
+BeforeDiscovery {
+    . "$PSScriptRoot/../../Helpers/TestTools.ps1"
+
+    $script:moduleToTest = Initialize-TestEnvironment
+}
+
+InModuleScope JiraAgilePS {
+    Describe "ConvertTo-Issue" -Tag 'Unit' {
+        BeforeAll {
+            . "$PSScriptRoot/../../Helpers/TestTools.ps1"
+
+            $script:issuePayload = [pscustomobject]@{
+                id     = '10010'
+                key    = 'DEL-10'
+                fields = [pscustomobject]@{
+                    summary = 'Fix board view'
+                }
+            }
+        }
+
+        Describe "Behavior" {
+            It "adds the Agile issue type name" {
+                $result = ConvertTo-Issue -InputObject $issuePayload
+
+                $result.PSObject.TypeNames[0] | Should -Be 'AtlassianPS.JiraAgilePS.Issue'
+            }
+
+            It "preserves all payload properties" {
+                $result = ConvertTo-Issue -InputObject $issuePayload
+
+                $result.id | Should -Be '10010'
+                $result.key | Should -Be 'DEL-10'
+                $result.fields.summary | Should -Be 'Fix board view'
+            }
+
+            It "ignores null pipeline input" {
+                $result = $null | ConvertTo-Issue
+
+                $result | Should -BeNullOrEmpty
+            }
+        }
+    }
+}

--- a/Tests/Functions/Private/ConvertTo-Sprint.Unit.Tests.ps1
+++ b/Tests/Functions/Private/ConvertTo-Sprint.Unit.Tests.ps1
@@ -1,0 +1,58 @@
+#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+
+BeforeDiscovery {
+    . "$PSScriptRoot/../../Helpers/TestTools.ps1"
+
+    $script:moduleToTest = Initialize-TestEnvironment
+}
+
+InModuleScope JiraAgilePS {
+    Describe "ConvertTo-Sprint" -Tag 'Unit' {
+        BeforeAll {
+            . "$PSScriptRoot/../../Helpers/TestTools.ps1"
+
+            $script:sprintPayload = [pscustomobject]@{
+                id            = 25
+                name          = 'Sprint 25'
+                state         = 'active'
+                startDate     = '2026-05-01T08:00:00.000Z'
+                endDate       = '2026-05-15T08:00:00.000Z'
+                completeDate  = '2026-05-16T08:00:00.000Z'
+                originBoardId = 7
+                goal          = 'Ship the board fixes'
+                self          = 'https://jira.example.com/rest/agile/1.0/sprint/25'
+            }
+        }
+
+        Describe "Behavior" {
+            BeforeAll {
+                $script:result = ConvertTo-Sprint -InputObject $sprintPayload
+            }
+
+            It "returns a typed sprint object" {
+                $result | Should -BeOfType ([AtlassianPS.JiraAgilePS.Sprint])
+            }
+
+            It "maps sprint properties" {
+                $result.Id | Should -Be 25
+                $result.Name | Should -Be 'Sprint 25'
+                $result.State | Should -Be ([AtlassianPS.JiraAgilePS.SprintState]::active)
+                $result.OriginBoardId | Should -Be 7
+                $result.Goal | Should -Be 'Ship the board fixes'
+                $result.Self.AbsoluteUri | Should -Be 'https://jira.example.com/rest/agile/1.0/sprint/25'
+            }
+
+            It "normalizes date values" {
+                $result.StartDate | Should -BeOfType ([System.DateTime])
+                $result.EndDate | Should -BeOfType ([System.DateTime])
+                $result.CompleteDate | Should -BeOfType ([System.DateTime])
+            }
+
+            It "accepts pipeline input" {
+                $pipelineResult = $sprintPayload | ConvertTo-Sprint
+
+                $pipelineResult.Id | Should -Be 25
+            }
+        }
+    }
+}

--- a/Tests/Functions/Private/Get-AgilePageItem.Unit.Tests.ps1
+++ b/Tests/Functions/Private/Get-AgilePageItem.Unit.Tests.ps1
@@ -1,0 +1,53 @@
+#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+
+BeforeDiscovery {
+    . "$PSScriptRoot/../../Helpers/TestTools.ps1"
+
+    $script:moduleToTest = Initialize-TestEnvironment
+}
+
+InModuleScope JiraAgilePS {
+    Describe "Get-AgilePageItem" -Tag 'Unit' {
+        Describe "Behavior" {
+            It "expands issues from a paged response" {
+                $response = [pscustomobject]@{
+                    issues = @(
+                        [pscustomobject]@{ key = 'DEL-1' }
+                        [pscustomobject]@{ key = 'DEL-2' }
+                    )
+                }
+
+                $result = @($response | Get-AgilePageItem)
+
+                $result.Key | Should -Be @('DEL-1', 'DEL-2')
+            }
+
+            It "expands values from a paged response" {
+                $response = [pscustomobject]@{
+                    values = @(
+                        [pscustomobject]@{ id = 1 }
+                        [pscustomobject]@{ id = 2 }
+                    )
+                }
+
+                $result = @($response | Get-AgilePageItem)
+
+                $result.Id | Should -Be @(1, 2)
+            }
+
+            It "returns input objects without a known page property" {
+                $inputObject = [pscustomobject]@{ name = 'plain object' }
+
+                $result = $inputObject | Get-AgilePageItem
+
+                $result.Name | Should -Be 'plain object'
+            }
+
+            It "ignores null input" {
+                $result = $null | Get-AgilePageItem
+
+                $result | Should -BeNullOrEmpty
+            }
+        }
+    }
+}

--- a/Tests/Functions/Private/README.md
+++ b/Tests/Functions/Private/README.md
@@ -1,0 +1,22 @@
+# Private Function Tests
+
+This directory contains unit tests for internal JiraAgilePS helpers and converters.
+
+## Pattern
+
+Use `Tests/Functions/Private/.template.ps1` for converter-style functions.
+Private tests should focus on the contract the public cmdlets depend on rather than duplicating implementation details.
+
+Converter tests should cover:
+
+- Object conversion and resulting type.
+- Property mapping from Jira Agile payload fields.
+- Type normalization, such as dates, URIs, booleans, and enum-backed values.
+- Pipeline behavior for single and multiple inputs.
+- Null input handling when the function explicitly supports it.
+
+Run a focused private function test with:
+
+```powershell
+Invoke-Pester -Path 'Tests/Functions/Private/ConvertTo-Board.Unit.Tests.ps1'
+```

--- a/Tests/Functions/Public/README.md
+++ b/Tests/Functions/Public/README.md
@@ -1,0 +1,19 @@
+# Public Function Tests
+
+This directory contains unit tests for exported JiraAgilePS cmdlets.
+
+## Pattern
+
+Public function tests should use `Tests/Functions/Public/.template.ps1` as the starting point.
+They usually cover these areas:
+
+- Signature: parameters, types, default values, and mandatory flags.
+- Behavior: REST method, URI, paging, body, and credential forwarding.
+- Output: conversion helper calls and returned objects.
+- Validation: accepted and rejected inputs when the cmdlet owns validation logic.
+
+Run a focused public function test with:
+
+```powershell
+Invoke-Pester -Path 'Tests/Functions/Public/Get-Board.Unit.Tests.ps1'
+```

--- a/Tests/README.md
+++ b/Tests/README.md
@@ -1,0 +1,51 @@
+# JiraAgilePS Testing Guide
+
+This guide explains the JiraAgilePS test layout and the expected commands for targeted and full validation.
+
+## Test Structure
+
+JiraAgilePS uses Pester 5.7+.
+Tests mirror the module structure so contributors can find the test for a function from its source path.
+
+- `Tests/Functions/Public/` contains unit tests for exported cmdlets.
+- `Tests/Functions/Private/` contains unit tests for internal converters and helpers.
+- `Tests/Helpers/` contains shared unit and integration test helpers.
+- `Tests/Integration/` contains live Jira Agile API tests and templates.
+
+## Test Templates
+
+Use the closest template when adding coverage:
+
+- `Tests/Functions/Public/.template.ps1` for public cmdlets that call Jira Agile REST endpoints.
+- `Tests/Functions/Private/.template.ps1` for private converters and data-shaping helpers.
+- `Tests/Integration/.template.ps1` for live API integration tests.
+
+Public cmdlet tests should cover signature, API call shape, conversion calls, and paging behavior where applicable.
+Private converter tests should cover object conversion, property mapping, null handling where supported, and pipeline behavior.
+
+## Running Tests
+
+Run focused tests while iterating:
+
+```powershell
+Invoke-Pester -Path 'Tests/Functions/Public/Get-Board.Unit.Tests.ps1'
+Invoke-Pester -Path 'Tests/Functions/Private/ConvertTo-Board.Unit.Tests.ps1'
+```
+
+Run the full repository gate before finishing work:
+
+```powershell
+./Tools/setup.ps1
+Invoke-Build -Task Build, Test
+```
+
+The default test task excludes integration tests.
+Run integration tests only when the change affects live Jira Agile behavior and the required environment values are available.
+
+## Writing Tests
+
+- Load the module with `Initialize-TestEnvironment` from `Tests/Helpers/TestTools.ps1`.
+- Use `InModuleScope JiraAgilePS` when testing private functions or mocking module-internal calls.
+- Keep test data local to the test file and remove personal or tenant-specific data from fixtures.
+- Prefer table-driven `-TestCases` for property mapping and signature checks.
+- Keep tests close to the behavior under change; do not add broad refactors as part of test-only work.


### PR DESCRIPTION
## Summary
- add JiraAgilePS test guidance docs for overall, public, and private test conventions
- add private unit tests for Agile converters and page expansion helper
- update changelog for issue #15

Closes #15.

## Validation
- Invoke-Pester -Path 'Tests/Functions/Private'
- Invoke-Build -Task Build, Test