### PR TITLE
Align website-facing docs indexes

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@ permalink: /module/JiraAgilePS/
 ---
 # [JiraAgilePS](https://atlassianps.org/module/JiraAgilePS)
 
-<!-- [![GitHub release](https://img.shields.io/github/release/AtlassianPS/JiraAgilePS.svg)](https://github.com/AtlassianPS/JiraAgilePS/releases/latest) [![Build status](https://img.shields.io/appveyor/ci/AtlassianPS/JiraAgilePS/master.svg)](https://ci.appveyor.com/project/AtlassianPS/jiraAgileps/branch/master) [![PowerShell Gallery](https://img.shields.io/powershellgallery/dt/JiraAgilePS.svg)](https://www.powershellgallery.com/packages/JiraAgilePS) ![License](https://img.shields.io/badge/license-MIT-blue.svg)-->
+[![Build Status](https://img.shields.io/github/actions/workflow/status/AtlassianPS/JiraAgilePS/ci.yml?style=for-the-badge)](https://github.com/AtlassianPS/JiraAgilePS/actions/workflows/ci.yml)
+[![PowerShell Gallery](https://img.shields.io/powershellgallery/dt/JiraAgilePS.svg?style=for-the-badge)](https://www.powershellgallery.com/packages/JiraAgilePS)
+![License](https://img.shields.io/badge/license-MIT-blue.svg?style=for-the-badge)
 
 JiraAgilePS is a PowerShell module to interact with _Agile_, Atlassian [JIRA]'s plugin,
 via a REST API, while maintaining a consistent PowerShell look and feel.
@@ -93,7 +95,16 @@ and [docker](https://docs.docker.com/engine/install/).
 When opening the repository in VS Code, it will recommend the installation of the extension.
 And once installed, you will be prompted to "Reopen in Container".
 
-## Acknowledgments
+## Tested on
+
+| Configuration | Status |
+| ------------- | ------ |
+| Windows PowerShell v5.1 | [CI workflow](https://github.com/AtlassianPS/JiraAgilePS/actions/workflows/ci.yml) |
+| PowerShell 7 on Windows | [CI workflow](https://github.com/AtlassianPS/JiraAgilePS/actions/workflows/ci.yml) |
+| PowerShell 7 on Ubuntu | [CI workflow](https://github.com/AtlassianPS/JiraAgilePS/actions/workflows/ci.yml) |
+| PowerShell 7 on macOS | [CI workflow](https://github.com/AtlassianPS/JiraAgilePS/actions/workflows/ci.yml) |
+
+## Acknowledgements
 
 * Thanks to everyone ([Our Contributors](https://atlassianps.org/#people)) that
   helped with this module
@@ -122,7 +133,7 @@ Hopefully this is obvious, but:
   [Submit an Issue]: https://github.com/AtlassianPS/JiraAgilePS/issues/new
   [replicaJunction]: https://github.com/replicaJunction
   [MIT license]: https://github.com/AtlassianPS/JiraAgilePS/blob/master/LICENSE
-  [Contributing]: http://atlassianps.org/docs/Contributing
+  [Contributing]: https://atlassianps.org/docs/Contributing/
 
 <!-- [//]: # (Sweet online markdown editor at http://dillinger.io) -->
 <!-- [//]: # ("GitHub Flavored Markdown" https://help.github.com/articles/github-flavored-markdown/) -->

--- a/docs/en-US/about_JiraAgilePS.md
+++ b/docs/en-US/about_JiraAgilePS.md
@@ -18,8 +18,8 @@ Use JiraAgilePS when you need Jira Software Agile REST operations from PowerShel
 
 ## SEE ALSO
 
-- [JiraAgilePS documentation index](index.html)
-- [Commands index](commands/index.html)
-- [Get-JiraAgileIssue](/docs/JiraAgilePS/commands/Get-JiraAgileIssue/)
-- [Get-JiraAgileBoardConfiguration](/docs/JiraAgilePS/commands/Get-JiraAgileBoardConfiguration/)
-- [Get-JiraAgileEpic](/docs/JiraAgilePS/commands/Get-JiraAgileEpic/)
+- [JiraAgilePS documentation index](/docs/JiraAgilePS/)
+- [Commands index](/docs/JiraAgilePS/commands/)
+- [Get-JiraAgileIssue](/docs/JiraAgilePS/commands/Get-Issue/)
+- [Get-JiraAgileBoardConfiguration](/docs/JiraAgilePS/commands/Get-BoardConfiguration/)
+- [Get-JiraAgileEpic](/docs/JiraAgilePS/commands/Get-Epic/)

--- a/docs/en-US/about_JiraAgilePS_AutomationPatterns.md
+++ b/docs/en-US/about_JiraAgilePS_AutomationPatterns.md
@@ -45,6 +45,6 @@ if (-not $issues) { throw "No issues matched the query." }
 
 # SEE ALSO
 
-- [Get-Board](commands/Get-Board.html)
-- [Get-Sprint](commands/Get-Sprint.html)
+- [Get-JiraAgileBoard](/docs/JiraAgilePS/commands/Get-Board/)
+- [Get-JiraAgileSprint](/docs/JiraAgilePS/commands/Get-Sprint/)
 - [Get-JiraIssue](https://atlassianps.org/docs/JiraPS/commands/Get-JiraIssue/)

--- a/docs/en-US/about_JiraAgilePS_BoardsAndSprints.md
+++ b/docs/en-US/about_JiraAgilePS_BoardsAndSprints.md
@@ -41,6 +41,6 @@ Use `-First` for quick script checks and `-PageSize` when tuning API payload siz
 
 # SEE ALSO
 
-- [Get-Board](commands/Get-Board.html)
-- [Get-Sprint](commands/Get-Sprint.html)
-- [Add-IssueToSprint](commands/Add-IssueToSprint.html)
+- [Get-JiraAgileBoard](/docs/JiraAgilePS/commands/Get-Board/)
+- [Get-JiraAgileSprint](/docs/JiraAgilePS/commands/Get-Sprint/)
+- [Add-JiraAgileIssueToSprint](/docs/JiraAgilePS/commands/Add-IssueToSprint/)

--- a/docs/en-US/commands/index.md
+++ b/docs/en-US/commands/index.md
@@ -5,10 +5,16 @@ hide: true
 ---
 # JiraAgilePS commands
 
-Read cmdlets added for first-release Agile scope:
+JiraAgilePS exports these commands with the `JiraAgile` default command prefix.
+The documentation pages use the source function names that back the exported commands.
 
-- [Get-JiraAgileIssue](/docs/JiraAgilePS/commands/Get-JiraAgileIssue/)
-- [Get-JiraAgileBoardConfiguration](/docs/JiraAgilePS/commands/Get-JiraAgileBoardConfiguration/)
-- [Get-JiraAgileEpic](/docs/JiraAgilePS/commands/Get-JiraAgileEpic/)
+| Exported command | Documentation |
+|---|---|
+| `Add-JiraAgileIssueToSprint` | [Add-IssueToSprint](/docs/JiraAgilePS/commands/Add-IssueToSprint/) |
+| `Get-JiraAgileBoard` | [Get-Board](/docs/JiraAgilePS/commands/Get-Board/) |
+| `Get-JiraAgileBoardConfiguration` | [Get-BoardConfiguration](/docs/JiraAgilePS/commands/Get-BoardConfiguration/) |
+| `Get-JiraAgileEpic` | [Get-Epic](/docs/JiraAgilePS/commands/Get-Epic/) |
+| `Get-JiraAgileIssue` | [Get-Issue](/docs/JiraAgilePS/commands/Get-Issue/) |
+| `Get-JiraAgileSprint` | [Get-Sprint](/docs/JiraAgilePS/commands/Get-Sprint/) |
 
 For module overview and setup, see [about_JiraAgilePS](/docs/JiraAgilePS/).

--- a/docs/en-US/index.md
+++ b/docs/en-US/index.md
@@ -8,10 +8,16 @@ hide: true
 ---
 # JiraAgilePS documentation
 
+JiraAgilePS adds Jira Software Agile commands on top of JiraPS.
+Use these docs for board, sprint, epic, and Agile issue automation.
+
 ## About topics
 
-- [about_JiraAgilePS](about_JiraAgilePS.html)
+- [about_JiraAgilePS](/docs/JiraAgilePS/about_JiraAgilePS/)
+- [Authentication](/docs/JiraAgilePS/about/authentication.html)
+- [Boards and Sprints](/docs/JiraAgilePS/about/boards-and-sprints.html)
+- [Automation Patterns](/docs/JiraAgilePS/about/automation-patterns.html)
 
 ## Commands
 
-- [Commands index](commands/index.html)
+- [Commands index](/docs/JiraAgilePS/commands/)


### PR DESCRIPTION
## Summary
- normalize README badges, useful links, tested platform table, and acknowledgements
- populate the docs root and command index for website rendering
- fix about-topic cross-links for JiraAgilePS docs

## Validation
- `Invoke-Pester -Path Tests/Help.Tests.ps1` passed: 30 passed, 68 skipped\n- `Invoke-Build -Task Build, Test` passed: 356 tests