### PR TITLE
Add first-release Jira Agile write cmdlets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@
 - Added `Get-JiraAgileEpic` with direct epic and board-scoped parameter sets for:
   - `GET /rest/agile/1.0/epic/{epicId}`
   - `GET /rest/agile/1.0/board/{boardId}/epic`
+- Added first-release write cmdlets for Jira Agile sprint and backlog operations:
+  - `Move-JiraAgileIssueToBacklog` for `POST /rest/agile/1.0/backlog/issue`
+  - `New-JiraAgileSprint` for `POST /rest/agile/1.0/sprint`
+  - `Set-JiraAgileSprint` for `PUT /rest/agile/1.0/sprint/{sprintId}`
+  - `Remove-JiraAgileSprint` for `DELETE /rest/agile/1.0/sprint/{sprintId}`
 - Added conversion helpers for paged Agile issue/epic responses and board configuration payloads
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@
 - Added first-release write cmdlets for Jira Agile sprint and backlog operations:
   - `Move-JiraAgileIssueToBacklog` for `POST /rest/agile/1.0/backlog/issue`
   - `New-JiraAgileSprint` for `POST /rest/agile/1.0/sprint`
-  - `Set-JiraAgileSprint` for `PUT /rest/agile/1.0/sprint/{sprintId}`
+  - `Set-JiraAgileSprint` for `POST /rest/agile/1.0/sprint/{sprintId}`
   - `Remove-JiraAgileSprint` for `DELETE /rest/agile/1.0/sprint/{sprintId}`
 - Added conversion helpers for paged Agile issue/epic responses and board configuration payloads
 

--- a/JiraAgilePS/Private/ConvertTo-JiraAgileDateString.ps1
+++ b/JiraAgilePS/Private/ConvertTo-JiraAgileDateString.ps1
@@ -1,0 +1,13 @@
+function ConvertTo-JiraAgileDateString {
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory, ValueFromPipeline)]
+        [DateTime]
+        $Date
+    )
+
+    process {
+        $Date.ToString("yyyy-MM-ddTHH:mm:ss.fffzzz", [Globalization.CultureInfo]::InvariantCulture)
+    }
+}

--- a/JiraAgilePS/Public/Move-IssueToBacklog.ps1
+++ b/JiraAgilePS/Public/Move-IssueToBacklog.ps1
@@ -1,0 +1,66 @@
+function Move-IssueToBacklog {
+    # .ExternalHelp ..\JiraAgilePS-help.xml
+    [CmdletBinding(SupportsShouldProcess)]
+    [OutputType([void])]
+    param(
+        [Parameter(Position = 0, Mandatory, ValueFromPipeline)]
+        $Issue,
+
+        [Parameter()]
+        [System.Management.Automation.PSCredential]
+        [System.Management.Automation.Credential()]
+        $Credential = [System.Management.Automation.PSCredential]::Empty
+    )
+
+    begin {
+        Write-Verbose "[$($MyInvocation.MyCommand.Name)] Function started"
+
+        $server = Get-JiraConfigServer -ErrorAction Stop
+        $resourceUrl = "$server/rest/agile/1.0/backlog/issue"
+        $issuesToProcess = New-Object -TypeName System.Collections.ArrayList
+    }
+
+    process {
+        Write-DebugMessage "[$($MyInvocation.MyCommand.Name)] ParameterSetName: $($PsCmdlet.ParameterSetName)"
+        Write-DebugMessage "[$($MyInvocation.MyCommand.Name)] PSBoundParameters: $($PSBoundParameters | Out-String)"
+
+        foreach ($_issue in $Issue) {
+            $null = $issuesToProcess.Add($_issue)
+        }
+    }
+
+    end {
+        while ($issuesToProcess.Count -gt 0) {
+            $thisPageSize = if ($issuesToProcess.Count -lt 50) { $issuesToProcess.Count } else { 50 }
+            $thisIssuePage = @($issuesToProcess | Select-Object -First $thisPageSize)
+            $issueKeys = @(
+                foreach ($_issue in $thisIssuePage) {
+                    if ($_issue.PSObject.Properties.Name -contains 'Key') {
+                        $_issue.Key
+                    }
+                    else {
+                        [string]$_issue
+                    }
+                }
+            )
+
+            if ($PSCmdlet.ShouldProcess(($issueKeys -join ', '), 'Move issues to Jira Agile backlog')) {
+                $requestParameter = @{
+                    Uri        = $resourceUrl
+                    Method     = "POST"
+                    Body       = ConvertTo-Json @{ issues = @($issueKeys) }
+                    Credential = $Credential
+                    Cmdlet     = $PSCmdlet
+                    Verbose    = $VerbosePreference
+                    Debug      = $DebugPreference
+                }
+                Write-Debug "[$($MyInvocation.MyCommand.Name)] Invoking JiraMethod with `$requestParameter"
+                Invoke-JiraMethod @requestParameter
+            }
+
+            $issuesToProcess.RemoveRange(0, $thisPageSize)
+        }
+
+        Write-Verbose "[$($MyInvocation.MyCommand.Name)] Complete"
+    }
+}

--- a/JiraAgilePS/Public/New-Sprint.ps1
+++ b/JiraAgilePS/Public/New-Sprint.ps1
@@ -1,0 +1,74 @@
+function New-Sprint {
+    # .ExternalHelp ..\JiraAgilePS-help.xml
+    [CmdletBinding(SupportsShouldProcess)]
+    [OutputType([AtlassianPS.JiraAgilePS.Sprint])]
+    param(
+        [Parameter(Mandatory)]
+        [string]
+        $Name,
+
+        [Parameter(Position = 0, Mandatory, ValueFromPipeline)]
+        [AtlassianPS.JiraAgilePS.Board]
+        $Board,
+
+        [Parameter()]
+        [DateTime]
+        $StartDate,
+
+        [Parameter()]
+        [DateTime]
+        $EndDate,
+
+        [Parameter()]
+        [string]
+        $Goal,
+
+        [Parameter()]
+        [System.Management.Automation.PSCredential]
+        [System.Management.Automation.Credential()]
+        $Credential = [System.Management.Automation.PSCredential]::Empty
+    )
+
+    begin {
+        Write-Verbose "[$($MyInvocation.MyCommand.Name)] Function started"
+
+        $server = Get-JiraConfigServer -ErrorAction Stop
+        $resourceUrl = "$server/rest/agile/1.0/sprint"
+    }
+
+    process {
+        Write-DebugMessage "[$($MyInvocation.MyCommand.Name)] ParameterSetName: $($PsCmdlet.ParameterSetName)"
+        Write-DebugMessage "[$($MyInvocation.MyCommand.Name)] PSBoundParameters: $($PSBoundParameters | Out-String)"
+
+        if ($Board.Id -eq 0) {
+            throw "[$($MyInvocation.MyCommand.Name)] Board input must contain a non-zero Id."
+        }
+
+        $body = @{
+            name          = $Name
+            originBoardId = $Board.Id
+        }
+        if ($PSBoundParameters.ContainsKey('StartDate')) { $body['startDate'] = $StartDate }
+        if ($PSBoundParameters.ContainsKey('EndDate')) { $body['endDate'] = $EndDate }
+        if ($PSBoundParameters.ContainsKey('Goal')) { $body['goal'] = $Goal }
+
+        if ($PSCmdlet.ShouldProcess($Name, "Create Jira Agile sprint on board $($Board.Id)")) {
+            $requestParameter = @{
+                Uri        = $resourceUrl
+                Method     = "POST"
+                Body       = ConvertTo-Json $body
+                Credential = $Credential
+                Cmdlet     = $PSCmdlet
+                Verbose    = $VerbosePreference
+                Debug      = $DebugPreference
+            }
+
+            Write-Debug "[$($MyInvocation.MyCommand.Name)] Invoking JiraMethod with `$requestParameter"
+            Invoke-JiraMethod @requestParameter | ConvertTo-Sprint
+        }
+    }
+
+    end {
+        Write-Verbose "[$($MyInvocation.MyCommand.Name)] Complete"
+    }
+}

--- a/JiraAgilePS/Public/New-Sprint.ps1
+++ b/JiraAgilePS/Public/New-Sprint.ps1
@@ -48,8 +48,8 @@ function New-Sprint {
             name          = $Name
             originBoardId = $Board.Id
         }
-        if ($PSBoundParameters.ContainsKey('StartDate')) { $body['startDate'] = $StartDate }
-        if ($PSBoundParameters.ContainsKey('EndDate')) { $body['endDate'] = $EndDate }
+        if ($PSBoundParameters.ContainsKey('StartDate')) { $body['startDate'] = ConvertTo-JiraAgileDateString $StartDate }
+        if ($PSBoundParameters.ContainsKey('EndDate')) { $body['endDate'] = ConvertTo-JiraAgileDateString $EndDate }
         if ($PSBoundParameters.ContainsKey('Goal')) { $body['goal'] = $Goal }
 
         if ($PSCmdlet.ShouldProcess($Name, "Create Jira Agile sprint on board $($Board.Id)")) {

--- a/JiraAgilePS/Public/Remove-Sprint.ps1
+++ b/JiraAgilePS/Public/Remove-Sprint.ps1
@@ -1,0 +1,51 @@
+function Remove-Sprint {
+    # .ExternalHelp ..\JiraAgilePS-help.xml
+    [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'High')]
+    [OutputType([void])]
+    param(
+        [Parameter(Position = 0, Mandatory, ValueFromPipeline)]
+        [AtlassianPS.JiraAgilePS.Sprint[]]
+        $Sprint,
+
+        [Parameter()]
+        [System.Management.Automation.PSCredential]
+        [System.Management.Automation.Credential()]
+        $Credential = [System.Management.Automation.PSCredential]::Empty
+    )
+
+    begin {
+        Write-Verbose "[$($MyInvocation.MyCommand.Name)] Function started"
+
+        $server = Get-JiraConfigServer -ErrorAction Stop
+        $resourceUrl = "$server/rest/agile/1.0/sprint/{0}"
+    }
+
+    process {
+        Write-DebugMessage "[$($MyInvocation.MyCommand.Name)] ParameterSetName: $($PsCmdlet.ParameterSetName)"
+        Write-DebugMessage "[$($MyInvocation.MyCommand.Name)] PSBoundParameters: $($PSBoundParameters | Out-String)"
+
+        foreach ($_sprint in $Sprint) {
+            if ($_sprint.Id -eq 0) {
+                throw "[$($MyInvocation.MyCommand.Name)] Sprint input must contain a non-zero Id."
+            }
+
+            if ($PSCmdlet.ShouldProcess("Sprint $($_sprint.Id)", 'Delete Jira Agile sprint')) {
+                $requestParameter = @{
+                    Uri        = $resourceUrl -f $_sprint.Id
+                    Method     = "DELETE"
+                    Credential = $Credential
+                    Cmdlet     = $PSCmdlet
+                    Verbose    = $VerbosePreference
+                    Debug      = $DebugPreference
+                }
+
+                Write-Debug "[$($MyInvocation.MyCommand.Name)] Invoking JiraMethod with `$requestParameter"
+                Invoke-JiraMethod @requestParameter
+            }
+        }
+    }
+
+    end {
+        Write-Verbose "[$($MyInvocation.MyCommand.Name)] Complete"
+    }
+}

--- a/JiraAgilePS/Public/Set-Sprint.ps1
+++ b/JiraAgilePS/Public/Set-Sprint.ps1
@@ -49,26 +49,17 @@ function Set-Sprint {
                 throw "[$($MyInvocation.MyCommand.Name)] Sprint input must contain a non-zero Id."
             }
 
-            $currentSprint = Get-Sprint -Sprint $_sprint -Credential $Credential -ErrorAction Stop
-
             $body = @{ }
-            if ($null -ne $currentSprint.Name) { $body['name'] = $currentSprint.Name }
-            if ($null -ne $currentSprint.State) { $body['state'] = $currentSprint.State.ToString() }
-            if ($null -ne $currentSprint.StartDate) { $body['startDate'] = $currentSprint.StartDate }
-            if ($null -ne $currentSprint.EndDate) { $body['endDate'] = $currentSprint.EndDate }
-            if ($currentSprint.OriginBoardId -ne 0) { $body['originBoardId'] = $currentSprint.OriginBoardId }
-            if ($null -ne $currentSprint.Goal) { $body['goal'] = $currentSprint.Goal }
-
             if ($PSBoundParameters.ContainsKey('Name')) { $body['name'] = $Name }
             if ($PSBoundParameters.ContainsKey('State')) { $body['state'] = $State.ToString() }
-            if ($PSBoundParameters.ContainsKey('StartDate')) { $body['startDate'] = $StartDate }
-            if ($PSBoundParameters.ContainsKey('EndDate')) { $body['endDate'] = $EndDate }
+            if ($PSBoundParameters.ContainsKey('StartDate')) { $body['startDate'] = ConvertTo-JiraAgileDateString $StartDate }
+            if ($PSBoundParameters.ContainsKey('EndDate')) { $body['endDate'] = ConvertTo-JiraAgileDateString $EndDate }
             if ($PSBoundParameters.ContainsKey('Goal')) { $body['goal'] = $Goal }
 
             if ($PSCmdlet.ShouldProcess("Sprint $($_sprint.Id)", 'Update Jira Agile sprint')) {
                 $requestParameter = @{
                     Uri        = $resourceUrl -f $_sprint.Id
-                    Method     = "PUT"
+                    Method     = "POST"
                     Body       = ConvertTo-Json $body
                     Credential = $Credential
                     Cmdlet     = $PSCmdlet

--- a/JiraAgilePS/Public/Set-Sprint.ps1
+++ b/JiraAgilePS/Public/Set-Sprint.ps1
@@ -1,0 +1,88 @@
+function Set-Sprint {
+    # .ExternalHelp ..\JiraAgilePS-help.xml
+    [CmdletBinding(SupportsShouldProcess)]
+    [OutputType([AtlassianPS.JiraAgilePS.Sprint])]
+    param(
+        [Parameter(Position = 0, Mandatory, ValueFromPipeline)]
+        [AtlassianPS.JiraAgilePS.Sprint[]]
+        $Sprint,
+
+        [Parameter()]
+        [string]
+        $Name,
+
+        [Parameter()]
+        [AtlassianPS.JiraAgilePS.SprintState]
+        $State,
+
+        [Parameter()]
+        [DateTime]
+        $StartDate,
+
+        [Parameter()]
+        [DateTime]
+        $EndDate,
+
+        [Parameter()]
+        [string]
+        $Goal,
+
+        [Parameter()]
+        [System.Management.Automation.PSCredential]
+        [System.Management.Automation.Credential()]
+        $Credential = [System.Management.Automation.PSCredential]::Empty
+    )
+
+    begin {
+        Write-Verbose "[$($MyInvocation.MyCommand.Name)] Function started"
+
+        $server = Get-JiraConfigServer -ErrorAction Stop
+        $resourceUrl = "$server/rest/agile/1.0/sprint/{0}"
+    }
+
+    process {
+        Write-DebugMessage "[$($MyInvocation.MyCommand.Name)] ParameterSetName: $($PsCmdlet.ParameterSetName)"
+        Write-DebugMessage "[$($MyInvocation.MyCommand.Name)] PSBoundParameters: $($PSBoundParameters | Out-String)"
+
+        foreach ($_sprint in $Sprint) {
+            if ($_sprint.Id -eq 0) {
+                throw "[$($MyInvocation.MyCommand.Name)] Sprint input must contain a non-zero Id."
+            }
+
+            $currentSprint = Get-Sprint -Sprint $_sprint -Credential $Credential -ErrorAction Stop
+
+            $body = @{ }
+            if ($null -ne $currentSprint.Name) { $body['name'] = $currentSprint.Name }
+            if ($null -ne $currentSprint.State) { $body['state'] = $currentSprint.State }
+            if ($null -ne $currentSprint.StartDate) { $body['startDate'] = $currentSprint.StartDate }
+            if ($null -ne $currentSprint.EndDate) { $body['endDate'] = $currentSprint.EndDate }
+            if ($currentSprint.OriginBoardId -ne 0) { $body['originBoardId'] = $currentSprint.OriginBoardId }
+            if ($null -ne $currentSprint.Goal) { $body['goal'] = $currentSprint.Goal }
+
+            if ($PSBoundParameters.ContainsKey('Name')) { $body['name'] = $Name }
+            if ($PSBoundParameters.ContainsKey('State')) { $body['state'] = $State }
+            if ($PSBoundParameters.ContainsKey('StartDate')) { $body['startDate'] = $StartDate }
+            if ($PSBoundParameters.ContainsKey('EndDate')) { $body['endDate'] = $EndDate }
+            if ($PSBoundParameters.ContainsKey('Goal')) { $body['goal'] = $Goal }
+
+            if ($PSCmdlet.ShouldProcess("Sprint $($_sprint.Id)", 'Update Jira Agile sprint')) {
+                $requestParameter = @{
+                    Uri        = $resourceUrl -f $_sprint.Id
+                    Method     = "PUT"
+                    Body       = ConvertTo-Json $body
+                    Credential = $Credential
+                    Cmdlet     = $PSCmdlet
+                    Verbose    = $VerbosePreference
+                    Debug      = $DebugPreference
+                }
+
+                Write-Debug "[$($MyInvocation.MyCommand.Name)] Invoking JiraMethod with `$requestParameter"
+                Invoke-JiraMethod @requestParameter | ConvertTo-Sprint
+            }
+        }
+    }
+
+    end {
+        Write-Verbose "[$($MyInvocation.MyCommand.Name)] Complete"
+    }
+}

--- a/JiraAgilePS/Public/Set-Sprint.ps1
+++ b/JiraAgilePS/Public/Set-Sprint.ps1
@@ -53,14 +53,14 @@ function Set-Sprint {
 
             $body = @{ }
             if ($null -ne $currentSprint.Name) { $body['name'] = $currentSprint.Name }
-            if ($null -ne $currentSprint.State) { $body['state'] = $currentSprint.State }
+            if ($null -ne $currentSprint.State) { $body['state'] = $currentSprint.State.ToString() }
             if ($null -ne $currentSprint.StartDate) { $body['startDate'] = $currentSprint.StartDate }
             if ($null -ne $currentSprint.EndDate) { $body['endDate'] = $currentSprint.EndDate }
             if ($currentSprint.OriginBoardId -ne 0) { $body['originBoardId'] = $currentSprint.OriginBoardId }
             if ($null -ne $currentSprint.Goal) { $body['goal'] = $currentSprint.Goal }
 
             if ($PSBoundParameters.ContainsKey('Name')) { $body['name'] = $Name }
-            if ($PSBoundParameters.ContainsKey('State')) { $body['state'] = $State }
+            if ($PSBoundParameters.ContainsKey('State')) { $body['state'] = $State.ToString() }
             if ($PSBoundParameters.ContainsKey('StartDate')) { $body['startDate'] = $StartDate }
             if ($PSBoundParameters.ContainsKey('EndDate')) { $body['endDate'] = $EndDate }
             if ($PSBoundParameters.ContainsKey('Goal')) { $body['goal'] = $Goal }

--- a/Tests/Functions/Public/Move-IssueToBacklog.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Move-IssueToBacklog.Unit.Tests.ps1
@@ -1,0 +1,112 @@
+#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+
+BeforeDiscovery {
+    . "$PSScriptRoot/../../Helpers/TestTools.ps1"
+
+    $script:moduleToTest = Initialize-TestEnvironment
+}
+
+BeforeAll {
+    . "$PSScriptRoot/../../Helpers/TestTools.ps1"
+    $script:moduleToTest = Initialize-TestEnvironment
+}
+
+Describe "Move-JiraAgileIssueToBacklog" -Tag 'Unit' {
+    BeforeAll {
+        $script:jiraServer = "https://jira.example.com"
+
+        Mock Get-JiraConfigServer -ModuleName JiraAgilePS {
+            $jiraServer
+        }
+    }
+
+    BeforeEach {
+        $script:postedBodies = [System.Collections.Generic.List[string]]::new()
+
+        Mock Invoke-JiraMethod -ModuleName JiraAgilePS {
+            param($Body)
+            $null = $script:postedBodies.Add($Body)
+        }
+    }
+
+    Describe "Signature" {
+        BeforeAll {
+            $script:command = Get-Command -Name "Move-JiraAgileIssueToBacklog"
+        }
+
+        Context "Parameter Types" {
+            It "has a parameter '<parameter>' of type '<type>'" -TestCases @(
+                @{ parameter = "Issue"; type = [Object] }
+                @{ parameter = "Credential"; type = [System.Management.Automation.PSCredential] }
+            ) {
+                $command | Should -HaveParameter $parameter -Type $type
+            }
+        }
+
+        Context "Default Values" {
+            It "parameter '<parameter>' has a default value of '<defaultValue>'" -TestCases @(
+                @{ parameter = "Credential"; defaultValue = "[System.Management.Automation.PSCredential]::Empty" }
+            ) {
+                $command | Should -HaveParameter $parameter -DefaultValue $defaultValue
+            }
+        }
+
+        Context "Mandatory Parameters" {
+            It "parameter '<parameter>' is mandatory" -TestCases @(
+                @{ parameter = "Issue" }
+            ) {
+                $command | Should -HaveParameter $parameter -Mandatory
+            }
+        }
+    }
+
+    Describe "Behavior" {
+        It "posts issue keys to the backlog endpoint" {
+            $issues = @(
+                [pscustomobject]@{ Key = "AG-1" }
+                [pscustomobject]@{ Key = "AG-2" }
+            )
+
+            { Move-JiraAgileIssueToBacklog -Issue $issues -Confirm:$false } | Should -Not -Throw
+
+            Should -Invoke -CommandName Invoke-JiraMethod -ModuleName JiraAgilePS -Exactly -Times 1 -Scope It -ParameterFilter {
+                $Method -eq "POST" -and
+                $Uri -eq "$jiraServer/rest/agile/1.0/backlog/issue" -and
+                (($Body | ConvertFrom-Json).issues -join ",") -eq "AG-1,AG-2"
+            }
+        }
+
+        It "accepts string issue identifiers" {
+            { Move-JiraAgileIssueToBacklog -Issue @("AG-3", "10004") -Confirm:$false } | Should -Not -Throw
+
+            Should -Invoke -CommandName Invoke-JiraMethod -ModuleName JiraAgilePS -Exactly -Times 1 -Scope It -ParameterFilter {
+                (($Body | ConvertFrom-Json).issues -join ",") -eq "AG-3,10004"
+            }
+        }
+
+        It "sends backlog payloads in pages of 50 issue keys" {
+            $issues = @(1..55 | ForEach-Object { [pscustomobject]@{ Key = "AG-$_" } })
+
+            { Move-JiraAgileIssueToBacklog -Issue $issues -Confirm:$false } | Should -Not -Throw
+
+            Should -Invoke -CommandName Invoke-JiraMethod -ModuleName JiraAgilePS -Exactly -Times 2 -Scope It
+
+            $firstBodyIssues = ($script:postedBodies[0] | ConvertFrom-Json).issues
+            $secondBodyIssues = ($script:postedBodies[1] | ConvertFrom-Json).issues
+
+            @($firstBodyIssues).Count | Should -Be 50
+            $firstBodyIssues[0] | Should -Be "AG-1"
+            $firstBodyIssues[-1] | Should -Be "AG-50"
+
+            @($secondBodyIssues).Count | Should -Be 5
+            $secondBodyIssues[0] | Should -Be "AG-51"
+            $secondBodyIssues[-1] | Should -Be "AG-55"
+        }
+
+        It "does not invoke Jira when WhatIf is used" {
+            Move-JiraAgileIssueToBacklog -Issue "AG-1" -WhatIf
+
+            Should -Invoke -CommandName Invoke-JiraMethod -ModuleName JiraAgilePS -Exactly -Times 0 -Scope It
+        }
+    }
+}

--- a/Tests/Functions/Public/New-Sprint.Unit.Tests.ps1
+++ b/Tests/Functions/Public/New-Sprint.Unit.Tests.ps1
@@ -67,8 +67,10 @@ Describe "New-JiraAgileSprint" -Tag 'Unit' {
     Describe "Behavior" {
         It "posts a sprint create payload and returns a typed sprint" {
             $board = [AtlassianPS.JiraAgilePS.Board]::new(9)
+            $startDate = [DateTime]'2026-06-01T00:00:00Z'
+            $endDate = [DateTime]'2026-06-14T00:00:00Z'
 
-            $result = New-JiraAgileSprint -Board $board -Name 'Sprint 101' -Goal 'Ship write cmdlets' -Confirm:$false
+            $result = New-JiraAgileSprint -Board $board -Name 'Sprint 101' -StartDate $startDate -EndDate $endDate -Goal 'Ship write cmdlets' -Confirm:$false
 
             Should -Invoke -CommandName Invoke-JiraMethod -ModuleName JiraAgilePS -Exactly -Times 1 -Scope It -ParameterFilter {
                 $payload = $Body | ConvertFrom-Json
@@ -76,7 +78,9 @@ Describe "New-JiraAgileSprint" -Tag 'Unit' {
                 $Uri -eq "$jiraServer/rest/agile/1.0/sprint" -and
                 $payload.name -eq 'Sprint 101' -and
                 $payload.originBoardId -eq 9 -and
-                $payload.goal -eq 'Ship write cmdlets'
+                $payload.goal -eq 'Ship write cmdlets' -and
+                $Body -match '"startDate"\s*:\s*"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}[+-]\d{2}:\d{2}"' -and
+                $Body -match '"endDate"\s*:\s*"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}[+-]\d{2}:\d{2}"'
             }
             $result | Should -BeOfType ([AtlassianPS.JiraAgilePS.Sprint])
             $result.Id | Should -Be 101

--- a/Tests/Functions/Public/New-Sprint.Unit.Tests.ps1
+++ b/Tests/Functions/Public/New-Sprint.Unit.Tests.ps1
@@ -1,0 +1,100 @@
+#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+
+BeforeDiscovery {
+    . "$PSScriptRoot/../../Helpers/TestTools.ps1"
+
+    $script:moduleToTest = Initialize-TestEnvironment
+}
+
+BeforeAll {
+    . "$PSScriptRoot/../../Helpers/TestTools.ps1"
+    $script:moduleToTest = Initialize-TestEnvironment
+}
+
+Describe "New-JiraAgileSprint" -Tag 'Unit' {
+    BeforeAll {
+        $script:jiraServer = "https://jira.example.com"
+
+        Mock Get-JiraConfigServer -ModuleName JiraAgilePS {
+            $jiraServer
+        }
+    }
+
+    BeforeEach {
+        Mock Invoke-JiraMethod -ModuleName JiraAgilePS {
+            [pscustomobject]@{
+                id            = 101
+                name          = 'Sprint 101'
+                state         = 'future'
+                startDate     = '2026-06-01T00:00:00.000Z'
+                endDate       = '2026-06-14T00:00:00.000Z'
+                completeDate  = $null
+                originBoardId = 9
+                goal          = 'Ship write cmdlets'
+                self          = "$jiraServer/rest/agile/1.0/sprint/101"
+            }
+        }
+    }
+
+    Describe "Signature" {
+        BeforeAll {
+            $script:command = Get-Command -Name "New-JiraAgileSprint"
+        }
+
+        Context "Parameter Types" {
+            It "has a parameter '<parameter>' of type '<type>'" -TestCases @(
+                @{ parameter = "Name"; type = [string] }
+                @{ parameter = "Board"; type = [AtlassianPS.JiraAgilePS.Board] }
+                @{ parameter = "StartDate"; type = [DateTime] }
+                @{ parameter = "EndDate"; type = [DateTime] }
+                @{ parameter = "Goal"; type = [string] }
+                @{ parameter = "Credential"; type = [System.Management.Automation.PSCredential] }
+            ) {
+                $command | Should -HaveParameter $parameter -Type $type
+            }
+        }
+
+        Context "Mandatory Parameters" {
+            It "parameter '<parameter>' is mandatory" -TestCases @(
+                @{ parameter = "Name" }
+                @{ parameter = "Board" }
+            ) {
+                $command | Should -HaveParameter $parameter -Mandatory
+            }
+        }
+    }
+
+    Describe "Behavior" {
+        It "posts a sprint create payload and returns a typed sprint" {
+            $board = [AtlassianPS.JiraAgilePS.Board]::new(9)
+
+            $result = New-JiraAgileSprint -Board $board -Name 'Sprint 101' -Goal 'Ship write cmdlets' -Confirm:$false
+
+            Should -Invoke -CommandName Invoke-JiraMethod -ModuleName JiraAgilePS -Exactly -Times 1 -Scope It -ParameterFilter {
+                $payload = $Body | ConvertFrom-Json
+                $Method -eq "POST" -and
+                $Uri -eq "$jiraServer/rest/agile/1.0/sprint" -and
+                $payload.name -eq 'Sprint 101' -and
+                $payload.originBoardId -eq 9 -and
+                $payload.goal -eq 'Ship write cmdlets'
+            }
+            $result | Should -BeOfType ([AtlassianPS.JiraAgilePS.Sprint])
+            $result.Id | Should -Be 101
+        }
+
+        It "throws when Board has no numeric id" {
+            $board = [AtlassianPS.JiraAgilePS.Board]::new("team-board")
+
+            { New-JiraAgileSprint -Board $board -Name 'Sprint 101' -Confirm:$false } |
+                Should -Throw "*Board input must contain a non-zero Id.*"
+        }
+
+        It "does not invoke Jira when WhatIf is used" {
+            $board = [AtlassianPS.JiraAgilePS.Board]::new(9)
+
+            New-JiraAgileSprint -Board $board -Name 'Sprint 101' -WhatIf
+
+            Should -Invoke -CommandName Invoke-JiraMethod -ModuleName JiraAgilePS -Exactly -Times 0 -Scope It
+        }
+    }
+}

--- a/Tests/Functions/Public/Remove-Sprint.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Remove-Sprint.Unit.Tests.ps1
@@ -1,0 +1,81 @@
+#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+
+BeforeDiscovery {
+    . "$PSScriptRoot/../../Helpers/TestTools.ps1"
+
+    $script:moduleToTest = Initialize-TestEnvironment
+}
+
+BeforeAll {
+    . "$PSScriptRoot/../../Helpers/TestTools.ps1"
+    $script:moduleToTest = Initialize-TestEnvironment
+}
+
+Describe "Remove-JiraAgileSprint" -Tag 'Unit' {
+    BeforeAll {
+        $script:jiraServer = "https://jira.example.com"
+
+        Mock Get-JiraConfigServer -ModuleName JiraAgilePS {
+            $jiraServer
+        }
+    }
+
+    BeforeEach {
+        Mock Invoke-JiraMethod -ModuleName JiraAgilePS { }
+    }
+
+    Describe "Signature" {
+        BeforeAll {
+            $script:command = Get-Command -Name "Remove-JiraAgileSprint"
+        }
+
+        Context "Parameter Types" {
+            It "has a parameter '<parameter>' of type '<type>'" -TestCases @(
+                @{ parameter = "Sprint"; type = [AtlassianPS.JiraAgilePS.Sprint[]] }
+                @{ parameter = "Credential"; type = [System.Management.Automation.PSCredential] }
+            ) {
+                $command | Should -HaveParameter $parameter -Type $type
+            }
+        }
+
+        Context "Mandatory Parameters" {
+            It "parameter '<parameter>' is mandatory" -TestCases @(
+                @{ parameter = "Sprint" }
+            ) {
+                $command | Should -HaveParameter $parameter -Mandatory
+            }
+        }
+    }
+
+    Describe "Behavior" {
+        It "deletes each supplied sprint" {
+            $sprintA = [AtlassianPS.JiraAgilePS.Sprint]::new(21)
+            $sprintB = [AtlassianPS.JiraAgilePS.Sprint]::new(22)
+
+            { Remove-JiraAgileSprint -Sprint @($sprintA, $sprintB) -Confirm:$false } | Should -Not -Throw
+
+            Should -Invoke -CommandName Invoke-JiraMethod -ModuleName JiraAgilePS -Exactly -Times 2 -Scope It
+            Should -Invoke -CommandName Invoke-JiraMethod -ModuleName JiraAgilePS -Exactly -Times 1 -Scope It -ParameterFilter {
+                $Method -eq "DELETE" -and $Uri -eq "$jiraServer/rest/agile/1.0/sprint/21"
+            }
+            Should -Invoke -CommandName Invoke-JiraMethod -ModuleName JiraAgilePS -Exactly -Times 1 -Scope It -ParameterFilter {
+                $Method -eq "DELETE" -and $Uri -eq "$jiraServer/rest/agile/1.0/sprint/22"
+            }
+        }
+
+        It "throws when Sprint has no numeric id" {
+            $sprint = [AtlassianPS.JiraAgilePS.Sprint]::new("sprint-name")
+
+            { Remove-JiraAgileSprint -Sprint $sprint -Confirm:$false } |
+                Should -Throw "*Sprint input must contain a non-zero Id.*"
+        }
+
+        It "does not invoke Jira when WhatIf is used" {
+            $sprint = [AtlassianPS.JiraAgilePS.Sprint]::new(21)
+
+            Remove-JiraAgileSprint -Sprint $sprint -WhatIf
+
+            Should -Invoke -CommandName Invoke-JiraMethod -ModuleName JiraAgilePS -Exactly -Times 0 -Scope It
+        }
+    }
+}

--- a/Tests/Functions/Public/Set-Sprint.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Set-Sprint.Unit.Tests.ps1
@@ -1,0 +1,116 @@
+#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+
+BeforeDiscovery {
+    . "$PSScriptRoot/../../Helpers/TestTools.ps1"
+
+    $script:moduleToTest = Initialize-TestEnvironment
+}
+
+BeforeAll {
+    . "$PSScriptRoot/../../Helpers/TestTools.ps1"
+    $script:moduleToTest = Initialize-TestEnvironment
+}
+
+Describe "Set-JiraAgileSprint" -Tag 'Unit' {
+    BeforeAll {
+        $script:jiraServer = "https://jira.example.com"
+
+        Mock Get-JiraConfigServer -ModuleName JiraAgilePS {
+            $jiraServer
+        }
+    }
+
+    BeforeEach {
+        Mock Get-Sprint -ModuleName JiraAgilePS {
+            [AtlassianPS.JiraAgilePS.Sprint]@{
+                Id            = 21
+                Name          = 'Sprint 21'
+                State         = [AtlassianPS.JiraAgilePS.SprintState]::future
+                StartDate     = [DateTime]'2026-06-01T00:00:00Z'
+                EndDate       = [DateTime]'2026-06-14T00:00:00Z'
+                OriginBoardId = 9
+                Goal          = 'Old goal'
+                Self          = [Uri]"$jiraServer/rest/agile/1.0/sprint/21"
+            }
+        }
+
+        Mock Invoke-JiraMethod -ModuleName JiraAgilePS {
+            [pscustomobject]@{
+                id            = 21
+                name          = 'Updated Sprint'
+                state         = 'active'
+                startDate     = '2026-06-01T00:00:00.000Z'
+                endDate       = '2026-06-14T00:00:00.000Z'
+                completeDate  = $null
+                originBoardId = 9
+                goal          = 'Updated goal'
+                self          = "$jiraServer/rest/agile/1.0/sprint/21"
+            }
+        }
+    }
+
+    Describe "Signature" {
+        BeforeAll {
+            $script:command = Get-Command -Name "Set-JiraAgileSprint"
+        }
+
+        Context "Parameter Types" {
+            It "has a parameter '<parameter>' of type '<type>'" -TestCases @(
+                @{ parameter = "Sprint"; type = [AtlassianPS.JiraAgilePS.Sprint[]] }
+                @{ parameter = "Name"; type = [string] }
+                @{ parameter = "State"; type = [AtlassianPS.JiraAgilePS.SprintState] }
+                @{ parameter = "StartDate"; type = [DateTime] }
+                @{ parameter = "EndDate"; type = [DateTime] }
+                @{ parameter = "Goal"; type = [string] }
+                @{ parameter = "Credential"; type = [System.Management.Automation.PSCredential] }
+            ) {
+                $command | Should -HaveParameter $parameter -Type $type
+            }
+        }
+
+        Context "Mandatory Parameters" {
+            It "parameter '<parameter>' is mandatory" -TestCases @(
+                @{ parameter = "Sprint" }
+            ) {
+                $command | Should -HaveParameter $parameter -Mandatory
+            }
+        }
+    }
+
+    Describe "Behavior" {
+        It "gets current sprint details, puts an update payload, and returns a typed sprint" {
+            $sprint = [AtlassianPS.JiraAgilePS.Sprint]::new(21)
+
+            $result = Set-JiraAgileSprint -Sprint $sprint -Name 'Updated Sprint' -State active -Goal 'Updated goal' -Confirm:$false
+
+            Should -Invoke -CommandName Get-Sprint -ModuleName JiraAgilePS -Exactly -Times 1 -Scope It
+            Should -Invoke -CommandName Invoke-JiraMethod -ModuleName JiraAgilePS -Exactly -Times 1 -Scope It -ParameterFilter {
+                $payload = $Body | ConvertFrom-Json
+                $Method -eq "PUT" -and
+                $Uri -eq "$jiraServer/rest/agile/1.0/sprint/21" -and
+                $payload.name -eq 'Updated Sprint' -and
+                $payload.state -eq 'active' -and
+                $payload.goal -eq 'Updated goal' -and
+                $payload.originBoardId -eq 9
+            }
+            $result | Should -BeOfType ([AtlassianPS.JiraAgilePS.Sprint])
+            $result.Name | Should -Be 'Updated Sprint'
+        }
+
+        It "throws when Sprint has no numeric id" {
+            $sprint = [AtlassianPS.JiraAgilePS.Sprint]::new("sprint-name")
+
+            { Set-JiraAgileSprint -Sprint $sprint -Name 'Updated Sprint' -Confirm:$false } |
+                Should -Throw "*Sprint input must contain a non-zero Id.*"
+        }
+
+        It "does not invoke the update when WhatIf is used" {
+            $sprint = [AtlassianPS.JiraAgilePS.Sprint]::new(21)
+
+            Set-JiraAgileSprint -Sprint $sprint -Name 'Updated Sprint' -WhatIf
+
+            Should -Invoke -CommandName Get-Sprint -ModuleName JiraAgilePS -Exactly -Times 1 -Scope It
+            Should -Invoke -CommandName Invoke-JiraMethod -ModuleName JiraAgilePS -Exactly -Times 0 -Scope It
+        }
+    }
+}

--- a/Tests/Functions/Public/Set-Sprint.Unit.Tests.ps1
+++ b/Tests/Functions/Public/Set-Sprint.Unit.Tests.ps1
@@ -21,19 +21,6 @@ Describe "Set-JiraAgileSprint" -Tag 'Unit' {
     }
 
     BeforeEach {
-        Mock Get-Sprint -ModuleName JiraAgilePS {
-            [AtlassianPS.JiraAgilePS.Sprint]@{
-                Id            = 21
-                Name          = 'Sprint 21'
-                State         = [AtlassianPS.JiraAgilePS.SprintState]::future
-                StartDate     = [DateTime]'2026-06-01T00:00:00Z'
-                EndDate       = [DateTime]'2026-06-14T00:00:00Z'
-                OriginBoardId = 9
-                Goal          = 'Old goal'
-                Self          = [Uri]"$jiraServer/rest/agile/1.0/sprint/21"
-            }
-        }
-
         Mock Invoke-JiraMethod -ModuleName JiraAgilePS {
             [pscustomobject]@{
                 id            = 21
@@ -78,20 +65,23 @@ Describe "Set-JiraAgileSprint" -Tag 'Unit' {
     }
 
     Describe "Behavior" {
-        It "gets current sprint details, puts an update payload, and returns a typed sprint" {
+        It "posts a partial update payload and returns a typed sprint" {
             $sprint = [AtlassianPS.JiraAgilePS.Sprint]::new(21)
+            $startDate = [DateTime]'2026-06-01T00:00:00Z'
+            $endDate = [DateTime]'2026-06-14T00:00:00Z'
 
-            $result = Set-JiraAgileSprint -Sprint $sprint -Name 'Updated Sprint' -State active -Goal 'Updated goal' -Confirm:$false
+            $result = Set-JiraAgileSprint -Sprint $sprint -Name 'Updated Sprint' -State active -StartDate $startDate -EndDate $endDate -Goal 'Updated goal' -Confirm:$false
 
-            Should -Invoke -CommandName Get-Sprint -ModuleName JiraAgilePS -Exactly -Times 1 -Scope It
             Should -Invoke -CommandName Invoke-JiraMethod -ModuleName JiraAgilePS -Exactly -Times 1 -Scope It -ParameterFilter {
                 $payload = $Body | ConvertFrom-Json
-                $Method -eq "PUT" -and
+                $Method -eq "POST" -and
                 $Uri -eq "$jiraServer/rest/agile/1.0/sprint/21" -and
                 $payload.name -eq 'Updated Sprint' -and
                 $payload.state -eq 'active' -and
                 $payload.goal -eq 'Updated goal' -and
-                $payload.originBoardId -eq 9
+                -not ($payload.PSObject.Properties.Name -contains 'originBoardId') -and
+                $Body -match '"startDate"\s*:\s*"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}[+-]\d{2}:\d{2}"' -and
+                $Body -match '"endDate"\s*:\s*"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}[+-]\d{2}:\d{2}"'
             }
             $result | Should -BeOfType ([AtlassianPS.JiraAgilePS.Sprint])
             $result.Name | Should -Be 'Updated Sprint'
@@ -109,7 +99,6 @@ Describe "Set-JiraAgileSprint" -Tag 'Unit' {
 
             Set-JiraAgileSprint -Sprint $sprint -Name 'Updated Sprint' -WhatIf
 
-            Should -Invoke -CommandName Get-Sprint -ModuleName JiraAgilePS -Exactly -Times 1 -Scope It
             Should -Invoke -CommandName Invoke-JiraMethod -ModuleName JiraAgilePS -Exactly -Times 0 -Scope It
         }
     }

--- a/Tests/Integration/AgileParity.Integration.Tests.ps1
+++ b/Tests/Integration/AgileParity.Integration.Tests.ps1
@@ -207,7 +207,8 @@ InModuleScope JiraAgilePS {
                 return
             }
 
-            $newSprint = New-JiraAgileSprint -Board $script:createdBoard -Name (New-TestResourceName -Type 'Sprint') -Goal 'Integration write coverage' -Confirm:$false -ErrorAction Stop
+            $sprintName = "JAPS-$([Guid]::NewGuid().ToString('N').Substring(0, 8))"
+            $newSprint = New-JiraAgileSprint -Board $script:createdBoard -Name $sprintName -Goal 'Integration write coverage' -Confirm:$false -ErrorAction Stop
 
             $newSprint.PSObject.TypeNames[0] | Should -Be 'AtlassianPS.JiraAgilePS.Sprint'
             $newSprint.Id | Should -Not -BeNullOrEmpty
@@ -245,7 +246,8 @@ InModuleScope JiraAgilePS {
                 return
             }
 
-            $sprintToDelete = New-JiraAgileSprint -Board $script:createdBoard -Name (New-TestResourceName -Type 'SprintDelete') -Confirm:$false -ErrorAction Stop
+            $sprintName = "JAPS-$([Guid]::NewGuid().ToString('N').Substring(0, 8))"
+            $sprintToDelete = New-JiraAgileSprint -Board $script:createdBoard -Name $sprintName -Confirm:$false -ErrorAction Stop
 
             { Remove-JiraAgileSprint -Sprint $sprintToDelete -Confirm:$false -ErrorAction Stop } | Should -Not -Throw
         }

--- a/Tests/Integration/AgileParity.Integration.Tests.ps1
+++ b/Tests/Integration/AgileParity.Integration.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
+#requires -modules @{ ModuleName = "Pester"; ModuleVersion = "5.7"; MaximumVersion = "5.999" }
 
 BeforeDiscovery {
     . "$PSScriptRoot/../Helpers/TestTools.ps1"
@@ -199,6 +199,55 @@ InModuleScope JiraAgilePS {
             }
 
             { Add-JiraAgileIssueToSprint -Issue $script:createdIssue -Sprint $script:sprints[0] -ErrorAction Stop } | Should -Not -Throw
+        }
+
+        It "can create a sprint through the public write cmdlet" {
+            if ($script:env.ReadOnly -or -not $script:createdBoard) {
+                Set-ItResult -Skipped -Because 'A writable temporary board is required for New-JiraAgileSprint coverage.'
+                return
+            }
+
+            $newSprint = New-JiraAgileSprint -Board $script:createdBoard -Name (New-TestResourceName -Type 'Sprint') -Goal 'Integration write coverage' -Confirm:$false -ErrorAction Stop
+
+            $newSprint.PSObject.TypeNames[0] | Should -Be 'AtlassianPS.JiraAgilePS.Sprint'
+            $newSprint.Id | Should -Not -BeNullOrEmpty
+
+            Invoke-JiraMethod -Uri "$($script:env.CloudUrl)/rest/agile/1.0/sprint/$($newSprint.Id)" -Method DELETE -ErrorAction SilentlyContinue
+        }
+
+        It "can update a sprint through the public write cmdlet" {
+            if ($script:env.ReadOnly -or -not $script:createdSprint) {
+                Set-ItResult -Skipped -Because 'A writable temporary sprint is required for Set-JiraAgileSprint coverage.'
+                return
+            }
+
+            $updatedGoal = New-TestResourceName -Type 'SprintGoal'
+            $updatedSprint = Set-JiraAgileSprint -Sprint $script:createdSprint -Goal $updatedGoal -Confirm:$false -ErrorAction Stop
+
+            $updatedSprint.PSObject.TypeNames[0] | Should -Be 'AtlassianPS.JiraAgilePS.Sprint'
+            $updatedSprint.Goal | Should -Be $updatedGoal
+        }
+
+        It "can move an issue to backlog through the public write cmdlet" {
+            if ($script:env.ReadOnly -or -not $script:createdIssue -or -not $script:createdSprint) {
+                Set-ItResult -Skipped -Because 'A temporary issue and sprint are required for Move-JiraAgileIssueToBacklog coverage.'
+                return
+            }
+
+            Add-JiraAgileIssueToSprint -Issue $script:createdIssue -Sprint $script:createdSprint -ErrorAction Stop
+
+            { Move-JiraAgileIssueToBacklog -Issue $script:createdIssue -Confirm:$false -ErrorAction Stop } | Should -Not -Throw
+        }
+
+        It "can delete a sprint through the public write cmdlet" {
+            if ($script:env.ReadOnly -or -not $script:createdBoard) {
+                Set-ItResult -Skipped -Because 'A writable temporary board is required for Remove-JiraAgileSprint coverage.'
+                return
+            }
+
+            $sprintToDelete = New-JiraAgileSprint -Board $script:createdBoard -Name (New-TestResourceName -Type 'SprintDelete') -Confirm:$false -ErrorAction Stop
+
+            { Remove-JiraAgileSprint -Sprint $sprintToDelete -Confirm:$false -ErrorAction Stop } | Should -Not -Throw
         }
     }
 }

--- a/docs/en-US/commands/Move-IssueToBacklog.md
+++ b/docs/en-US/commands/Move-IssueToBacklog.md
@@ -1,0 +1,110 @@
+---
+external help file: JiraAgilePS-help.xml
+Module Name: JiraAgilePS
+online version: https://atlassianps.org/docs/JiraAgilePS/commands/Move-IssueToBacklog/
+locale: en-US
+layout: documentation
+permalink: /docs/JiraAgilePS/commands/Move-IssueToBacklog/
+---
+# Move-IssueToBacklog
+
+## SYNOPSIS
+
+Moves Jira issues to the Jira Agile backlog.
+
+## SYNTAX
+
+```powershell
+Move-IssueToBacklog [-Issue] <Object> [-Credential <PSCredential>] [-WhatIf] [-Confirm] [<CommonParameters>]
+```
+
+## DESCRIPTION
+
+`Move-IssueToBacklog` removes future and active sprint assignments from one or more Jira issues by calling the Jira Agile backlog endpoint.
+
+The command submits issue keys in request batches of 50.
+
+When imported normally, run this command as `Move-JiraAgileIssueToBacklog`.
+
+## EXAMPLES
+
+### EXAMPLE 1
+
+```powershell
+$issue = Get-JiraIssue -Issue "PROJ-123" -Credential $cred
+JiraAgilePS\Move-IssueToBacklog -Issue $issue -Credential $cred
+```
+
+Moves one Jira issue to the backlog.
+
+### EXAMPLE 2
+
+```powershell
+$issues = Get-JiraIssue -Query 'project = PROJ AND sprint is not EMPTY' -Credential $cred
+$issues | JiraAgilePS\Move-IssueToBacklog -Credential $cred
+```
+
+Pipes multiple Jira issues to the backlog command.
+
+## PARAMETERS
+
+### -Issue
+
+Issue object or issue key to move to the backlog.
+
+```yaml
+Type: Object
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 0
+Default value: None
+Accept pipeline input: True (ByValue)
+Accept wildcard characters: False
+```
+
+### -Credential
+
+Credentials used for Jira authentication.
+
+```yaml
+Type: PSCredential
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: [System.Management.Automation.PSCredential]::Empty
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutBuffer, -OutVariable, -PipelineVariable,
+-ProgressAction, -Verbose, -WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### System.Object
+
+Issue object(s) from JiraPS commands, for example `Get-JiraIssue`, or issue key strings.
+
+## OUTPUTS
+
+### System.Void
+
+## NOTES
+
+This command does not emit output on success.
+
+Use `Move-JiraAgileIssueToBacklog` in normal module usage. `Move-IssueToBacklog` is the source function name.
+
+## RELATED LINKS
+
+[Add-IssueToSprint](Add-IssueToSprint.html)
+
+[Get-Issue](Get-Issue.html)

--- a/docs/en-US/commands/New-Sprint.md
+++ b/docs/en-US/commands/New-Sprint.md
@@ -1,0 +1,170 @@
+---
+external help file: JiraAgilePS-help.xml
+Module Name: JiraAgilePS
+online version: https://atlassianps.org/docs/JiraAgilePS/commands/New-Sprint/
+locale: en-US
+layout: documentation
+permalink: /docs/JiraAgilePS/commands/New-Sprint/
+---
+# New-Sprint
+
+## SYNOPSIS
+
+Creates a Jira Agile sprint.
+
+## SYNTAX
+
+```powershell
+New-Sprint [-Board] <Board> -Name <String> [-StartDate <DateTime>] [-EndDate <DateTime>] [-Goal <String>] [-Credential <PSCredential>] [-WhatIf] [-Confirm] [<CommonParameters>]
+```
+
+## DESCRIPTION
+
+`New-Sprint` creates a future sprint on a Jira Agile board.
+
+The Jira Agile API requires a sprint name and origin board ID. Start date, end date, and goal are optional.
+
+When imported normally, run this command as `New-JiraAgileSprint`.
+
+## EXAMPLES
+
+### EXAMPLE 1
+
+```powershell
+$board = JiraAgilePS\Get-Board -BoardId 7 -Credential $cred
+JiraAgilePS\New-Sprint -Board $board -Name "Sprint 42" -Credential $cred
+```
+
+Creates a future sprint on board 7.
+
+### EXAMPLE 2
+
+```powershell
+$board = JiraAgilePS\Get-Board -BoardId 7 -Credential $cred
+JiraAgilePS\New-Sprint -Board $board -Name "Sprint 42" -StartDate (Get-Date) -EndDate (Get-Date).AddDays(14) -Goal "Ship API write cmdlets" -Credential $cred
+```
+
+Creates a sprint with dates and a goal.
+
+## PARAMETERS
+
+### -Board
+
+Board object where the sprint will be created.
+
+```yaml
+Type: Board
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 0
+Default value: None
+Accept pipeline input: True (ByValue)
+Accept wildcard characters: False
+```
+
+### -Name
+
+Name of the sprint to create.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -StartDate
+
+Optional sprint start date.
+
+```yaml
+Type: DateTime
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -EndDate
+
+Optional sprint end date.
+
+```yaml
+Type: DateTime
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Goal
+
+Optional sprint goal.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Credential
+
+Credentials used for Jira authentication.
+
+```yaml
+Type: PSCredential
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: [System.Management.Automation.PSCredential]::Empty
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutBuffer, -OutVariable, -PipelineVariable,
+-ProgressAction, -Verbose, -WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### AtlassianPS.JiraAgilePS.Board
+
+## OUTPUTS
+
+### AtlassianPS.JiraAgilePS.Sprint
+
+## NOTES
+
+Use `New-JiraAgileSprint` in normal module usage. `New-Sprint` is the source function name.
+
+## RELATED LINKS
+
+[Get-Board](Get-Board.html)
+
+[Get-Sprint](Get-Sprint.html)

--- a/docs/en-US/commands/Remove-Sprint.md
+++ b/docs/en-US/commands/Remove-Sprint.md
@@ -1,0 +1,108 @@
+---
+external help file: JiraAgilePS-help.xml
+Module Name: JiraAgilePS
+online version: https://atlassianps.org/docs/JiraAgilePS/commands/Remove-Sprint/
+locale: en-US
+layout: documentation
+permalink: /docs/JiraAgilePS/commands/Remove-Sprint/
+---
+# Remove-Sprint
+
+## SYNOPSIS
+
+Deletes Jira Agile sprints.
+
+## SYNTAX
+
+```powershell
+Remove-Sprint [-Sprint] <Sprint[]> [-Credential <PSCredential>] [-WhatIf] [-Confirm] [<CommonParameters>]
+```
+
+## DESCRIPTION
+
+`Remove-Sprint` deletes one or more Jira Agile sprints.
+
+When Jira deletes a sprint, open issues in that sprint are moved to the backlog.
+
+When imported normally, run this command as `Remove-JiraAgileSprint`.
+
+## EXAMPLES
+
+### EXAMPLE 1
+
+```powershell
+$sprint = [AtlassianPS.JiraAgilePS.Sprint]::new(42)
+JiraAgilePS\Remove-Sprint -Sprint $sprint -Credential $cred -Confirm:$false
+```
+
+Deletes sprint 42 without an interactive confirmation prompt.
+
+### EXAMPLE 2
+
+```powershell
+$sprints = JiraAgilePS\Get-Sprint -Board $board -State Future -Credential $cred
+$sprints | JiraAgilePS\Remove-Sprint -Credential $cred -WhatIf
+```
+
+Shows which future sprints would be deleted without deleting them.
+
+## PARAMETERS
+
+### -Sprint
+
+Sprint object(s) to delete.
+
+```yaml
+Type: Sprint[]
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 0
+Default value: None
+Accept pipeline input: True (ByValue)
+Accept wildcard characters: False
+```
+
+### -Credential
+
+Credentials used for Jira authentication.
+
+```yaml
+Type: PSCredential
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: [System.Management.Automation.PSCredential]::Empty
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutBuffer, -OutVariable, -PipelineVariable,
+-ProgressAction, -Verbose, -WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### AtlassianPS.JiraAgilePS.Sprint[]
+
+## OUTPUTS
+
+### System.Void
+
+## NOTES
+
+This command does not emit output on success.
+
+Use `Remove-JiraAgileSprint` in normal module usage. `Remove-Sprint` is the source function name.
+
+## RELATED LINKS
+
+[Get-Sprint](Get-Sprint.html)
+
+[New-Sprint](New-Sprint.html)

--- a/docs/en-US/commands/Set-Sprint.md
+++ b/docs/en-US/commands/Set-Sprint.md
@@ -20,9 +20,9 @@ Set-Sprint [-Sprint] <Sprint[]> [-Name <String>] [-State <SprintState>] [-StartD
 
 ## DESCRIPTION
 
-`Set-Sprint` updates one or more Jira Agile sprints using the Jira Agile full-update endpoint.
+`Set-Sprint` updates one or more Jira Agile sprints using the Jira Agile partial-update endpoint.
 
-The command first retrieves the current sprint and then submits existing values plus the values you provide. Jira treats this endpoint as a full update, so fields missing from both the retrieved sprint and the command parameters may be set to null by Jira.
+Only the values you provide are submitted to Jira. Fields omitted from the command are left unchanged by Jira.
 
 When imported normally, run this command as `Set-JiraAgileSprint`.
 

--- a/docs/en-US/commands/Set-Sprint.md
+++ b/docs/en-US/commands/Set-Sprint.md
@@ -1,0 +1,186 @@
+---
+external help file: JiraAgilePS-help.xml
+Module Name: JiraAgilePS
+online version: https://atlassianps.org/docs/JiraAgilePS/commands/Set-Sprint/
+locale: en-US
+layout: documentation
+permalink: /docs/JiraAgilePS/commands/Set-Sprint/
+---
+# Set-Sprint
+
+## SYNOPSIS
+
+Updates Jira Agile sprints.
+
+## SYNTAX
+
+```powershell
+Set-Sprint [-Sprint] <Sprint[]> [-Name <String>] [-State <SprintState>] [-StartDate <DateTime>] [-EndDate <DateTime>] [-Goal <String>] [-Credential <PSCredential>] [-WhatIf] [-Confirm] [<CommonParameters>]
+```
+
+## DESCRIPTION
+
+`Set-Sprint` updates one or more Jira Agile sprints using the Jira Agile full-update endpoint.
+
+The command first retrieves the current sprint and then submits existing values plus the values you provide. Jira treats this endpoint as a full update, so fields missing from both the retrieved sprint and the command parameters may be set to null by Jira.
+
+When imported normally, run this command as `Set-JiraAgileSprint`.
+
+## EXAMPLES
+
+### EXAMPLE 1
+
+```powershell
+$sprint = [AtlassianPS.JiraAgilePS.Sprint]::new(42)
+JiraAgilePS\Set-Sprint -Sprint $sprint -Name "Sprint 42 - revised" -Goal "Complete the release candidate" -Credential $cred
+```
+
+Updates the sprint name and goal.
+
+### EXAMPLE 2
+
+```powershell
+$sprint = [AtlassianPS.JiraAgilePS.Sprint]::new(42)
+JiraAgilePS\Set-Sprint -Sprint $sprint -State Active -StartDate (Get-Date) -EndDate (Get-Date).AddDays(14) -Credential $cred
+```
+
+Starts a future sprint by setting state and dates.
+
+## PARAMETERS
+
+### -Sprint
+
+Sprint object(s) to update.
+
+```yaml
+Type: Sprint[]
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 0
+Default value: None
+Accept pipeline input: True (ByValue)
+Accept wildcard characters: False
+```
+
+### -Name
+
+Updated sprint name.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -State
+
+Updated sprint state.
+
+```yaml
+Type: SprintState
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -StartDate
+
+Updated sprint start date.
+
+```yaml
+Type: DateTime
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -EndDate
+
+Updated sprint end date.
+
+```yaml
+Type: DateTime
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Goal
+
+Updated sprint goal.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Credential
+
+Credentials used for Jira authentication.
+
+```yaml
+Type: PSCredential
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: [System.Management.Automation.PSCredential]::Empty
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable,
+-InformationAction, -InformationVariable, -OutBuffer, -OutVariable, -PipelineVariable,
+-ProgressAction, -Verbose, -WarningAction, and -WarningVariable. For more information, see
+[about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### AtlassianPS.JiraAgilePS.Sprint[]
+
+## OUTPUTS
+
+### AtlassianPS.JiraAgilePS.Sprint
+
+## NOTES
+
+Use `Set-JiraAgileSprint` in normal module usage. `Set-Sprint` is the source function name.
+
+## RELATED LINKS
+
+[Get-Sprint](Get-Sprint.html)
+
+[New-Sprint](New-Sprint.html)

--- a/docs/en-US/commands/index.md
+++ b/docs/en-US/commands/index.md
@@ -16,5 +16,9 @@ The documentation pages use the source function names that back the exported com
 | `Get-JiraAgileEpic` | [Get-Epic](/docs/JiraAgilePS/commands/Get-Epic/) |
 | `Get-JiraAgileIssue` | [Get-Issue](/docs/JiraAgilePS/commands/Get-Issue/) |
 | `Get-JiraAgileSprint` | [Get-Sprint](/docs/JiraAgilePS/commands/Get-Sprint/) |
+| `Move-JiraAgileIssueToBacklog` | [Move-IssueToBacklog](/docs/JiraAgilePS/commands/Move-IssueToBacklog/) |
+| `New-JiraAgileSprint` | [New-Sprint](/docs/JiraAgilePS/commands/New-Sprint/) |
+| `Remove-JiraAgileSprint` | [Remove-Sprint](/docs/JiraAgilePS/commands/Remove-Sprint/) |
+| `Set-JiraAgileSprint` | [Set-Sprint](/docs/JiraAgilePS/commands/Set-Sprint/) |
 
 For module overview and setup, see [about_JiraAgilePS](/docs/JiraAgilePS/).


### PR DESCRIPTION
## Summary
- add first-release Jira Agile write cmdlets for backlog move and sprint create/update/delete
- add public unit coverage for request composition, batching, validation, and WhatIf behavior
- add command docs, changelog entry, and guarded full parity integration coverage

Closes #14

## Validation
- Invoke-Pester -Path 'Tests/Functions/Public/Move-IssueToBacklog.Unit.Tests.ps1', 'Tests/Functions/Public/New-Sprint.Unit.Tests.ps1', 'Tests/Functions/Public/Set-Sprint.Unit.Tests.ps1', 'Tests/Functions/Public/Remove-Sprint.Unit.Tests.ps1'
- ./Tools/setup.ps1; Invoke-Build -Task Build, Test