### PR TITLE
docs: improve website reference navigation

### DIFF
--- a/docs/en-US/about_JiraAgilePS.md
+++ b/docs/en-US/about_JiraAgilePS.md
@@ -18,7 +18,18 @@ Use JiraAgilePS when you need Jira Software Agile REST operations from PowerShel
 
 ## SEE ALSO
 
+- [Authentication](/docs/JiraAgilePS/about/authentication.html)
+- [Automation Patterns](/docs/JiraAgilePS/about/automation-patterns.html)
+- [Boards and Sprints](/docs/JiraAgilePS/about/boards-and-sprints.html)
 - [Commands index](/docs/JiraAgilePS/commands/)
 - [Get-JiraAgileIssue](/docs/JiraAgilePS/commands/Get-Issue/)
 - [Get-JiraAgileBoardConfiguration](/docs/JiraAgilePS/commands/Get-BoardConfiguration/)
 - [Get-JiraAgileEpic](/docs/JiraAgilePS/commands/Get-Epic/)
+
+## Guides
+
+<div class="reference-index">
+    <a href="/docs/JiraAgilePS/about/authentication.html">Authentication</a>
+    <a href="/docs/JiraAgilePS/about/automation-patterns.html">Automation Patterns</a>
+    <a href="/docs/JiraAgilePS/about/boards-and-sprints.html">Boards and Sprints</a>
+</div>

--- a/docs/en-US/commands/Add-IssueToSprint.md
+++ b/docs/en-US/commands/Add-IssueToSprint.md
@@ -136,6 +136,6 @@ Use `Add-JiraAgileIssueToSprint` in normal module usage. `Add-IssueToSprint` is 
 
 ## RELATED LINKS
 
-[Get-Board](Get-Board.html)
+[Get-Board](../Get-Board/)
 
-[Get-Sprint](Get-Sprint.html)
+[Get-Sprint](../Get-Sprint/)

--- a/docs/en-US/commands/Get-Board.md
+++ b/docs/en-US/commands/Get-Board.md
@@ -182,6 +182,6 @@ Use `Get-JiraAgileBoard` in normal module usage. `Get-Board` is the source funct
 
 ## RELATED LINKS
 
-[Get-Sprint](Get-Sprint.html)
+[Get-Sprint](../Get-Sprint/)
 
-[Add-IssueToSprint](Add-IssueToSprint.html)
+[Add-IssueToSprint](../Add-IssueToSprint/)

--- a/docs/en-US/commands/Get-BoardConfiguration.md
+++ b/docs/en-US/commands/Get-BoardConfiguration.md
@@ -92,6 +92,6 @@ Use `Get-JiraAgileBoardConfiguration` in normal module usage. `Get-BoardConfigur
 
 ## RELATED LINKS
 
-[Get-Issue](Get-Issue.html)
+[Get-Issue](../Get-Issue/)
 
 [Commands index](/docs/JiraAgilePS/commands/)

--- a/docs/en-US/commands/Get-Epic.md
+++ b/docs/en-US/commands/Get-Epic.md
@@ -192,4 +192,4 @@ Use `Get-JiraAgileEpic` in normal module usage. `Get-Epic` is the source functio
 
 ## RELATED LINKS
 
-[Get-Issue](Get-Issue.html)
+[Get-Issue](../Get-Issue/)

--- a/docs/en-US/commands/Get-Issue.md
+++ b/docs/en-US/commands/Get-Issue.md
@@ -308,6 +308,6 @@ Use `Get-JiraAgileIssue` in normal module usage. `Get-Issue` is the source funct
 
 ## RELATED LINKS
 
-[Get-BoardConfiguration](Get-BoardConfiguration.html)
+[Get-BoardConfiguration](../Get-BoardConfiguration/)
 
-[Get-Epic](Get-Epic.html)
+[Get-Epic](../Get-Epic/)

--- a/docs/en-US/commands/Get-Sprint.md
+++ b/docs/en-US/commands/Get-Sprint.md
@@ -231,6 +231,6 @@ Use `Get-JiraAgileSprint` in normal module usage. `Get-Sprint` is the source fun
 
 ## RELATED LINKS
 
-[Get-Board](Get-Board.html)
+[Get-Board](../Get-Board/)
 
-[Add-IssueToSprint](Add-IssueToSprint.html)
+[Add-IssueToSprint](../Add-IssueToSprint/)

--- a/docs/en-US/commands/Move-IssueToBacklog.md
+++ b/docs/en-US/commands/Move-IssueToBacklog.md
@@ -105,6 +105,6 @@ Use `Move-JiraAgileIssueToBacklog` in normal module usage. `Move-IssueToBacklog`
 
 ## RELATED LINKS
 
-[Add-IssueToSprint](Add-IssueToSprint.html)
+[Add-IssueToSprint](../Add-IssueToSprint/)
 
-[Get-Issue](Get-Issue.html)
+[Get-Issue](../Get-Issue/)

--- a/docs/en-US/commands/New-Sprint.md
+++ b/docs/en-US/commands/New-Sprint.md
@@ -165,6 +165,6 @@ Use `New-JiraAgileSprint` in normal module usage. `New-Sprint` is the source fun
 
 ## RELATED LINKS
 
-[Get-Board](Get-Board.html)
+[Get-Board](../Get-Board/)
 
-[Get-Sprint](Get-Sprint.html)
+[Get-Sprint](../Get-Sprint/)

--- a/docs/en-US/commands/Remove-Sprint.md
+++ b/docs/en-US/commands/Remove-Sprint.md
@@ -103,6 +103,6 @@ Use `Remove-JiraAgileSprint` in normal module usage. `Remove-Sprint` is the sour
 
 ## RELATED LINKS
 
-[Get-Sprint](Get-Sprint.html)
+[Get-Sprint](../Get-Sprint/)
 
-[New-Sprint](New-Sprint.html)
+[New-Sprint](../New-Sprint/)

--- a/docs/en-US/commands/Set-Sprint.md
+++ b/docs/en-US/commands/Set-Sprint.md
@@ -181,6 +181,6 @@ Use `Set-JiraAgileSprint` in normal module usage. `Set-Sprint` is the source fun
 
 ## RELATED LINKS
 
-[Get-Sprint](Get-Sprint.html)
+[Get-Sprint](../Get-Sprint/)
 
-[New-Sprint](New-Sprint.html)
+[New-Sprint](../New-Sprint/)

--- a/docs/en-US/commands/index.md
+++ b/docs/en-US/commands/index.md
@@ -1,7 +1,6 @@
 ---
 layout: documentation
 permalink: /docs/JiraAgilePS/commands/
-hide: true
 ---
 # JiraAgilePS commands
 


### PR DESCRIPTION
## Summary
- expose JiraAgilePS guide links from the module overview
- unhide the website command index
- fix related-command links so generated website docs resolve correctly, including sprint and backlog pages added upstream

## Validation
- documentation-only change
- rebased on current master
- validated through the AtlassianPS.github.io generated-site link audit